### PR TITLE
program: introduce core BPF tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3175,7 +3175,6 @@ dependencies = [
 name = "scbpf-address-lookup-table"
 version = "0.1.0"
 dependencies = [
- "assert_matches",
  "bincode",
  "bytemuck",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3175,6 +3175,7 @@ dependencies = [
 name = "scbpf-address-lookup-table"
 version = "0.1.0"
 dependencies = [
+ "assert_matches",
  "bincode",
  "bytemuck",
  "log",
@@ -3183,6 +3184,7 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-program",
+ "solana-program-test",
  "solana-sdk",
  "spl-program-error",
  "test-case",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -24,6 +24,8 @@ solana-program = "1.18.2"
 spl-program-error = "0.3.1"
 
 [dev-dependencies]
+assert_matches = "1.5.0"
+solana-program-test = "1.18.2"
 solana-sdk = "1.18.2"
 test-case = "3.3.1"
 

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -24,7 +24,6 @@ solana-program = "1.18.2"
 spl-program-error = "0.3.1"
 
 [dev-dependencies]
-assert_matches = "1.5.0"
 solana-program-test = "1.18.2"
 solana-sdk = "1.18.2"
 test-case = "3.3.1"

--- a/program/tests/close_lookup_table_ix.rs
+++ b/program/tests/close_lookup_table_ix.rs
@@ -1,0 +1,229 @@
+#![cfg(feature = "test-sbf")]
+
+use {
+    assert_matches::assert_matches,
+    common::{
+        add_lookup_table_account, assert_ix_error, new_address_lookup_table, setup_test_context,
+    },
+    scbpf_address_lookup_table::instruction::close_lookup_table,
+    solana_program_test::*,
+    solana_sdk::{
+        clock::Clock,
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        slot_hashes::SlotHashes,
+        sysvar::Sysvar,
+        transaction::Transaction,
+    },
+};
+
+mod common;
+
+#[tokio::test]
+async fn test_close_lookup_table() {
+    let mut context = setup_test_context().await;
+    context
+        .warp_to_slot(SlotHashes::size_of() as u64 + 1)
+        .unwrap();
+
+    let lookup_table_address = Pubkey::new_unique();
+    let authority_keypair = Keypair::new();
+    let initialized_table = {
+        let mut table = new_address_lookup_table(Some(authority_keypair.pubkey()), 0);
+        table.meta.deactivation_slot = 0;
+        table
+    };
+    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+
+    let client = &mut context.banks_client;
+    let payer = &context.payer;
+    let recent_blockhash = context.last_blockhash;
+    let transaction = Transaction::new_signed_with_payer(
+        &[close_lookup_table(
+            lookup_table_address,
+            authority_keypair.pubkey(),
+            context.payer.pubkey(),
+        )],
+        Some(&payer.pubkey()),
+        &[payer, &authority_keypair],
+        recent_blockhash,
+    );
+
+    assert_matches!(client.process_transaction(transaction).await, Ok(()));
+    assert!(client
+        .get_account(lookup_table_address)
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn test_close_lookup_table_not_deactivated() {
+    let mut context = setup_test_context().await;
+
+    let authority_keypair = Keypair::new();
+    let initialized_table = new_address_lookup_table(Some(authority_keypair.pubkey()), 0);
+    let lookup_table_address = Pubkey::new_unique();
+    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+
+    let ix = close_lookup_table(
+        lookup_table_address,
+        authority_keypair.pubkey(),
+        context.payer.pubkey(),
+    );
+
+    // The ix should fail because the table hasn't been deactivated yet
+    assert_ix_error(
+        &mut context,
+        ix,
+        Some(&authority_keypair),
+        InstructionError::InvalidArgument,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_close_lookup_table_deactivated_in_current_slot() {
+    let mut context = setup_test_context().await;
+
+    let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
+    let authority_keypair = Keypair::new();
+    let initialized_table = {
+        let mut table = new_address_lookup_table(Some(authority_keypair.pubkey()), 0);
+        table.meta.deactivation_slot = clock.slot;
+        table
+    };
+    let lookup_table_address = Pubkey::new_unique();
+    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+
+    let ix = close_lookup_table(
+        lookup_table_address,
+        authority_keypair.pubkey(),
+        context.payer.pubkey(),
+    );
+
+    // [Core BPF]: This still holds true while using `Clock`.
+    // Context sets up the slot hashes sysvar to have an entry
+    // for slot 0 which is when the table was deactivated.
+    // Because that slot is present, the ix should fail.
+    assert_ix_error(
+        &mut context,
+        ix,
+        Some(&authority_keypair),
+        InstructionError::InvalidArgument,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_close_lookup_table_recently_deactivated() {
+    let mut context = setup_test_context().await;
+
+    let authority_keypair = Keypair::new();
+    let initialized_table = {
+        let mut table = new_address_lookup_table(Some(authority_keypair.pubkey()), 0);
+        table.meta.deactivation_slot = 0;
+        table
+    };
+    let lookup_table_address = Pubkey::new_unique();
+    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+
+    let ix = close_lookup_table(
+        lookup_table_address,
+        authority_keypair.pubkey(),
+        context.payer.pubkey(),
+    );
+
+    // [Core BPF]: This still holds true while using `Clock`.
+    // Context sets up the slot hashes sysvar to have an entry
+    // for slot 0 which is when the table was deactivated.
+    // Because that slot is present, the ix should fail.
+    assert_ix_error(
+        &mut context,
+        ix,
+        Some(&authority_keypair),
+        InstructionError::InvalidArgument,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_close_immutable_lookup_table() {
+    let mut context = setup_test_context().await;
+
+    let initialized_table = new_address_lookup_table(None, 10);
+    let lookup_table_address = Pubkey::new_unique();
+    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+
+    let authority = Keypair::new();
+    let ix = close_lookup_table(
+        lookup_table_address,
+        authority.pubkey(),
+        Pubkey::new_unique(),
+    );
+
+    assert_ix_error(
+        &mut context,
+        ix,
+        Some(&authority),
+        // [Core BPF]: TODO: Should be `ProgramError::Immutable`
+        // See https://github.com/solana-labs/solana/pull/35113
+        // InstructionError::Immutable,
+        InstructionError::Custom(0),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_close_lookup_table_with_wrong_authority() {
+    let mut context = setup_test_context().await;
+
+    let authority = Keypair::new();
+    let wrong_authority = Keypair::new();
+    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
+    let lookup_table_address = Pubkey::new_unique();
+    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+
+    let ix = close_lookup_table(
+        lookup_table_address,
+        wrong_authority.pubkey(),
+        Pubkey::new_unique(),
+    );
+
+    assert_ix_error(
+        &mut context,
+        ix,
+        Some(&wrong_authority),
+        // [Core BPF]: TODO: Should be `ProgramError::Immutable`
+        // See https://github.com/solana-labs/solana/pull/35113
+        // InstructionError::IncorrectAuthority,
+        InstructionError::Custom(0),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_close_lookup_table_without_signing() {
+    let mut context = setup_test_context().await;
+
+    let authority = Keypair::new();
+    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
+    let lookup_table_address = Pubkey::new_unique();
+    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+
+    let mut ix = close_lookup_table(
+        lookup_table_address,
+        authority.pubkey(),
+        Pubkey::new_unique(),
+    );
+    ix.accounts[1].is_signer = false;
+
+    assert_ix_error(
+        &mut context,
+        ix,
+        None,
+        InstructionError::MissingRequiredSignature,
+    )
+    .await;
+}

--- a/program/tests/close_lookup_table_ix.rs
+++ b/program/tests/close_lookup_table_ix.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "test-sbf")]
 
 use {
-    assert_matches::assert_matches,
     common::{
         add_lookup_table_account, assert_ix_error, new_address_lookup_table, setup_test_context,
     },
@@ -50,7 +49,10 @@ async fn test_close_lookup_table() {
         recent_blockhash,
     );
 
-    assert_matches!(client.process_transaction(transaction).await, Ok(()));
+    assert!(matches!(
+        client.process_transaction(transaction).await,
+        Ok(())
+    ));
     assert!(client
         .get_account(lookup_table_address)
         .await

--- a/program/tests/close_lookup_table_ix.rs
+++ b/program/tests/close_lookup_table_ix.rs
@@ -22,7 +22,7 @@ mod common;
 async fn test_close_lookup_table() {
     // Succesfully close a deactived lookup table.
     let mut context = setup_test_context().await;
-    context.warp_to_slot(MAX_ENTRIES as u64 + 1).unwrap();
+    context.warp_to_slot(MAX_ENTRIES as u64).unwrap();
 
     let lookup_table_address = Pubkey::new_unique();
     let authority_keypair = Keypair::new();

--- a/program/tests/common.rs
+++ b/program/tests/common.rs
@@ -1,0 +1,93 @@
+#![allow(dead_code)]
+#![cfg(feature = "test-sbf")]
+
+use {
+    scbpf_address_lookup_table::state::{AddressLookupTable, LookupTableMeta},
+    solana_program_test::*,
+    solana_sdk::{
+        account::AccountSharedData,
+        instruction::{Instruction, InstructionError},
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        transaction::{Transaction, TransactionError},
+    },
+    std::borrow::Cow,
+};
+
+pub async fn setup_test_context() -> ProgramTestContext {
+    let mut program_test = ProgramTest::default();
+    program_test.prefer_bpf(false);
+    program_test.add_program(
+        "scbpf_address_lookup_table",
+        scbpf_address_lookup_table::id(),
+        processor!(scbpf_address_lookup_table::processor::process),
+    );
+    program_test.start_with_context().await
+}
+
+pub async fn assert_ix_error(
+    context: &mut ProgramTestContext,
+    ix: Instruction,
+    authority_keypair: Option<&Keypair>,
+    expected_err: InstructionError,
+) {
+    let client = &mut context.banks_client;
+    let payer = &context.payer;
+    let recent_blockhash = context.last_blockhash;
+
+    let mut signers = vec![payer];
+    if let Some(authority) = authority_keypair {
+        signers.push(authority);
+    }
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &signers,
+        recent_blockhash,
+    );
+
+    assert_eq!(
+        client
+            .process_transaction(transaction)
+            .await
+            .unwrap_err()
+            .unwrap(),
+        TransactionError::InstructionError(0, expected_err),
+    );
+}
+
+pub fn new_address_lookup_table(
+    authority: Option<Pubkey>,
+    num_addresses: usize,
+) -> AddressLookupTable<'static> {
+    let mut addresses = Vec::with_capacity(num_addresses);
+    addresses.resize_with(num_addresses, Pubkey::new_unique);
+    AddressLookupTable {
+        meta: LookupTableMeta {
+            authority,
+            ..LookupTableMeta::default()
+        },
+        addresses: Cow::Owned(addresses),
+    }
+}
+
+pub async fn add_lookup_table_account(
+    context: &mut ProgramTestContext,
+    account_address: Pubkey,
+    address_lookup_table: AddressLookupTable<'static>,
+) -> AccountSharedData {
+    let data = address_lookup_table.serialize_for_tests().unwrap();
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let rent_exempt_balance = rent.minimum_balance(data.len());
+
+    let mut account = AccountSharedData::new(
+        rent_exempt_balance,
+        data.len(),
+        &scbpf_address_lookup_table::id(),
+    );
+    account.set_data_from_slice(&data);
+    context.set_account(&account_address, &account);
+
+    account
+}

--- a/program/tests/common.rs
+++ b/program/tests/common.rs
@@ -16,7 +16,7 @@ use {
 
 pub async fn setup_test_context() -> ProgramTestContext {
     let mut program_test = ProgramTest::default();
-    program_test.prefer_bpf(false);
+    program_test.prefer_bpf(true);
     program_test.add_program(
         "scbpf_address_lookup_table",
         scbpf_address_lookup_table::id(),

--- a/program/tests/create_lookup_table_ix.rs
+++ b/program/tests/create_lookup_table_ix.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "test-sbf")]
 
 use {
-    assert_matches::assert_matches,
     common::{assert_ix_error, setup_test_context},
     scbpf_address_lookup_table::{
         instruction::create_lookup_table,
@@ -45,7 +44,10 @@ async fn test_create_lookup_table_idempotent() {
             recent_blockhash,
         );
 
-        assert_matches!(client.process_transaction(transaction).await, Ok(()));
+        assert!(matches!(
+            client.process_transaction(transaction).await,
+            Ok(())
+        ));
         let lookup_table_account = client
             .get_account(lookup_table_address)
             .await
@@ -78,7 +80,10 @@ async fn test_create_lookup_table_idempotent() {
             recent_blockhash,
         );
 
-        assert_matches!(client.process_transaction(transaction).await, Ok(()));
+        assert!(matches!(
+            client.process_transaction(transaction).await,
+            Ok(())
+        ));
     }
 }
 

--- a/program/tests/create_lookup_table_ix.rs
+++ b/program/tests/create_lookup_table_ix.rs
@@ -1,0 +1,117 @@
+#![cfg(feature = "test-sbf")]
+
+use {
+    assert_matches::assert_matches,
+    common::{assert_ix_error, setup_test_context},
+    scbpf_address_lookup_table::{
+        instruction::create_lookup_table,
+        state::{AddressLookupTable, LOOKUP_TABLE_META_SIZE},
+    },
+    solana_program_test::*,
+    solana_sdk::{
+        clock::Slot, instruction::InstructionError, pubkey::Pubkey, rent::Rent, signature::Signer,
+        transaction::Transaction,
+    },
+};
+
+mod common;
+
+// [Core BPF]: Tests that assert proper authority checks have been removed,
+// since feature "FKAcEvNgSY79RpqsPNUV5gDyumopH4cEHqUxyfm8b8Ap"
+// (relax_authority_signer_check_for_lookup_table_creation) has been activated
+// on all clusters.
+
+#[tokio::test]
+async fn test_create_lookup_table_idempotent() {
+    let mut context = setup_test_context().await;
+
+    let test_recent_slot = 123;
+    // [Core BPF]: Warping to slot instead of overwriting `SlotHashes`.
+    context.warp_to_slot(test_recent_slot + 1).unwrap();
+
+    let client = &mut context.banks_client;
+    let payer = &context.payer;
+    let recent_blockhash = context.last_blockhash;
+    let authority_address = Pubkey::new_unique();
+    let (create_lookup_table_ix, lookup_table_address) =
+        create_lookup_table(authority_address, payer.pubkey(), test_recent_slot);
+
+    // First create should succeed
+    {
+        let transaction = Transaction::new_signed_with_payer(
+            &[create_lookup_table_ix.clone()],
+            Some(&payer.pubkey()),
+            &[payer],
+            recent_blockhash,
+        );
+
+        assert_matches!(client.process_transaction(transaction).await, Ok(()));
+        let lookup_table_account = client
+            .get_account(lookup_table_address)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(lookup_table_account.owner, scbpf_address_lookup_table::id());
+        assert_eq!(lookup_table_account.data.len(), LOOKUP_TABLE_META_SIZE);
+        assert_eq!(
+            lookup_table_account.lamports,
+            Rent::default().minimum_balance(LOOKUP_TABLE_META_SIZE)
+        );
+        let lookup_table = AddressLookupTable::deserialize(&lookup_table_account.data).unwrap();
+        assert_eq!(lookup_table.meta.deactivation_slot, Slot::MAX);
+        assert_eq!(lookup_table.meta.authority, Some(authority_address));
+        assert_eq!(lookup_table.meta.last_extended_slot, 0);
+        assert_eq!(lookup_table.meta.last_extended_slot_start_index, 0);
+        assert_eq!(lookup_table.addresses.len(), 0);
+    }
+
+    // Second create should succeed too
+    {
+        let recent_blockhash = client
+            .get_new_latest_blockhash(&recent_blockhash)
+            .await
+            .unwrap();
+        let transaction = Transaction::new_signed_with_payer(
+            &[create_lookup_table_ix],
+            Some(&payer.pubkey()),
+            &[payer],
+            recent_blockhash,
+        );
+
+        assert_matches!(client.process_transaction(transaction).await, Ok(()));
+    }
+}
+
+#[tokio::test]
+async fn test_create_lookup_table_not_recent_slot() {
+    let mut context = setup_test_context().await;
+    let payer = &context.payer;
+    let authority_address = Pubkey::new_unique();
+
+    let ix = create_lookup_table(authority_address, payer.pubkey(), Slot::MAX).0;
+
+    assert_ix_error(
+        &mut context,
+        ix,
+        None,
+        InstructionError::InvalidInstructionData,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_create_lookup_table_pda_mismatch() {
+    let mut context = setup_test_context().await;
+
+    let test_recent_slot = 123;
+    // [Core BPF]: Warping to slot instead of overwriting `SlotHashes`.
+    context.warp_to_slot(test_recent_slot + 1).unwrap();
+
+    let payer = &context.payer;
+    let authority_address = Pubkey::new_unique();
+
+    let mut ix = create_lookup_table(authority_address, payer.pubkey(), test_recent_slot).0;
+    ix.accounts[0].pubkey = Pubkey::new_unique();
+
+    assert_ix_error(&mut context, ix, None, InstructionError::InvalidArgument).await;
+}

--- a/program/tests/deactivate_lookup_table_ix.rs
+++ b/program/tests/deactivate_lookup_table_ix.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "test-sbf")]
 
 use {
-    assert_matches::assert_matches,
     common::{
         add_lookup_table_account, assert_ix_error, new_address_lookup_table, setup_test_context,
     },
@@ -44,7 +43,10 @@ async fn test_deactivate_lookup_table() {
         recent_blockhash,
     );
 
-    assert_matches!(client.process_transaction(transaction).await, Ok(()));
+    assert!(matches!(
+        client.process_transaction(transaction).await,
+        Ok(())
+    ));
     let table_account = client
         .get_account(lookup_table_address)
         .await

--- a/program/tests/deactivate_lookup_table_ix.rs
+++ b/program/tests/deactivate_lookup_table_ix.rs
@@ -1,0 +1,151 @@
+#![cfg(feature = "test-sbf")]
+
+use {
+    assert_matches::assert_matches,
+    common::{
+        add_lookup_table_account, assert_ix_error, new_address_lookup_table, setup_test_context,
+    },
+    scbpf_address_lookup_table::{instruction::deactivate_lookup_table, state::AddressLookupTable},
+    solana_program_test::*,
+    solana_sdk::{
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
+};
+
+mod common;
+
+#[tokio::test]
+async fn test_deactivate_lookup_table() {
+    let mut context = setup_test_context().await;
+
+    let authority = Keypair::new();
+    let mut initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
+    let lookup_table_address = Pubkey::new_unique();
+    add_lookup_table_account(
+        &mut context,
+        lookup_table_address,
+        initialized_table.clone(),
+    )
+    .await;
+
+    let client = &mut context.banks_client;
+    let payer = &context.payer;
+    let recent_blockhash = context.last_blockhash;
+    let transaction = Transaction::new_signed_with_payer(
+        &[deactivate_lookup_table(
+            lookup_table_address,
+            authority.pubkey(),
+        )],
+        Some(&payer.pubkey()),
+        &[payer, &authority],
+        recent_blockhash,
+    );
+
+    assert_matches!(client.process_transaction(transaction).await, Ok(()));
+    let table_account = client
+        .get_account(lookup_table_address)
+        .await
+        .unwrap()
+        .unwrap();
+    let lookup_table = AddressLookupTable::deserialize(&table_account.data).unwrap();
+    assert_eq!(lookup_table.meta.deactivation_slot, 1);
+
+    // Check that only the deactivation slot changed
+    initialized_table.meta.deactivation_slot = 1;
+    assert_eq!(initialized_table, lookup_table);
+}
+
+#[tokio::test]
+async fn test_deactivate_immutable_lookup_table() {
+    let mut context = setup_test_context().await;
+
+    let initialized_table = new_address_lookup_table(None, 10);
+    let lookup_table_address = Pubkey::new_unique();
+    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+
+    let authority = Keypair::new();
+    let ix = deactivate_lookup_table(lookup_table_address, authority.pubkey());
+
+    assert_ix_error(
+        &mut context,
+        ix,
+        Some(&authority),
+        // [Core BPF]: TODO: Should be `ProgramError::Immutable`
+        // See https://github.com/solana-labs/solana/pull/35113
+        // InstructionError::Immutable,
+        InstructionError::Custom(0),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_deactivate_already_deactivated() {
+    let mut context = setup_test_context().await;
+
+    let authority = Keypair::new();
+    let initialized_table = {
+        let mut table = new_address_lookup_table(Some(authority.pubkey()), 0);
+        table.meta.deactivation_slot = 0;
+        table
+    };
+    let lookup_table_address = Pubkey::new_unique();
+    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+
+    let ix = deactivate_lookup_table(lookup_table_address, authority.pubkey());
+
+    assert_ix_error(
+        &mut context,
+        ix,
+        Some(&authority),
+        InstructionError::InvalidArgument,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_deactivate_lookup_table_with_wrong_authority() {
+    let mut context = setup_test_context().await;
+
+    let authority = Keypair::new();
+    let wrong_authority = Keypair::new();
+    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
+    let lookup_table_address = Pubkey::new_unique();
+    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+
+    let ix = deactivate_lookup_table(lookup_table_address, wrong_authority.pubkey());
+
+    assert_ix_error(
+        &mut context,
+        ix,
+        Some(&wrong_authority),
+        // [Core BPF]: TODO: Should be `ProgramError::Immutable`
+        // See https://github.com/solana-labs/solana/pull/35113
+        // InstructionError::IncorrectAuthority,
+        InstructionError::Custom(0),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_deactivate_lookup_table_without_signing() {
+    let mut context = setup_test_context().await;
+
+    let authority = Keypair::new();
+    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
+    let lookup_table_address = Pubkey::new_unique();
+    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+
+    let mut ix = deactivate_lookup_table(lookup_table_address, authority.pubkey());
+    ix.accounts[1].is_signer = false;
+
+    assert_ix_error(
+        &mut context,
+        ix,
+        None,
+        InstructionError::MissingRequiredSignature,
+    )
+    .await;
+}

--- a/program/tests/extend_lookup_table_ix.rs
+++ b/program/tests/extend_lookup_table_ix.rs
@@ -1,0 +1,355 @@
+#![cfg(feature = "test-sbf")]
+
+use {
+    assert_matches::assert_matches,
+    common::{
+        add_lookup_table_account, assert_ix_error, new_address_lookup_table, setup_test_context,
+    },
+    scbpf_address_lookup_table::{
+        instruction::extend_lookup_table,
+        state::{AddressLookupTable, LookupTableMeta},
+    },
+    solana_program_test::*,
+    solana_sdk::{
+        account::{ReadableAccount, WritableAccount},
+        clock::Clock,
+        instruction::{Instruction, InstructionError},
+        pubkey::{Pubkey, PUBKEY_BYTES},
+        signature::{Keypair, Signer},
+        transaction::{Transaction, TransactionError},
+    },
+    std::{borrow::Cow, result::Result},
+};
+
+mod common;
+
+struct ExpectedTableAccount {
+    lamports: u64,
+    data_len: usize,
+    state: AddressLookupTable<'static>,
+}
+
+struct TestCase<'a> {
+    lookup_table_address: Pubkey,
+    instruction: Instruction,
+    extra_signer: Option<&'a Keypair>,
+    expected_result: Result<ExpectedTableAccount, InstructionError>,
+}
+
+async fn run_test_case(context: &mut ProgramTestContext, test_case: TestCase<'_>) {
+    let client = &mut context.banks_client;
+    let payer = &context.payer;
+    let recent_blockhash = context.last_blockhash;
+
+    let mut signers = vec![payer];
+    if let Some(extra_signer) = test_case.extra_signer {
+        signers.push(extra_signer);
+    }
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[test_case.instruction],
+        Some(&payer.pubkey()),
+        &signers,
+        recent_blockhash,
+    );
+
+    let process_result = client.process_transaction(transaction).await;
+
+    match test_case.expected_result {
+        Ok(expected_account) => {
+            assert_matches!(process_result, Ok(()));
+
+            let table_account = client
+                .get_account(test_case.lookup_table_address)
+                .await
+                .unwrap()
+                .unwrap();
+
+            let lookup_table = AddressLookupTable::deserialize(&table_account.data).unwrap();
+            assert_eq!(lookup_table, expected_account.state);
+            assert_eq!(table_account.lamports(), expected_account.lamports);
+            assert_eq!(table_account.data().len(), expected_account.data_len);
+        }
+        Err(expected_err) => {
+            assert_eq!(
+                process_result.unwrap_err().unwrap(),
+                TransactionError::InstructionError(0, expected_err),
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_extend_lookup_table() {
+    let mut context = setup_test_context().await;
+    let authority = Keypair::new();
+    let current_bank_slot = 1;
+    let rent = context.banks_client.get_rent().await.unwrap();
+
+    for extend_same_slot in [true, false] {
+        for (num_existing_addresses, num_new_addresses, expected_result) in [
+            (0, 0, Err(InstructionError::InvalidInstructionData)),
+            (0, 1, Ok(())),
+            (0, 10, Ok(())),
+            (1, 1, Ok(())),
+            (1, 10, Ok(())),
+            (255, 1, Ok(())),
+            (255, 2, Err(InstructionError::InvalidInstructionData)),
+            (246, 10, Ok(())),
+            (256, 1, Err(InstructionError::InvalidArgument)),
+        ] {
+            let mut lookup_table =
+                new_address_lookup_table(Some(authority.pubkey()), num_existing_addresses);
+            if extend_same_slot {
+                lookup_table.meta.last_extended_slot = current_bank_slot;
+            }
+
+            let lookup_table_address = Pubkey::new_unique();
+            let lookup_table_account =
+                add_lookup_table_account(&mut context, lookup_table_address, lookup_table.clone())
+                    .await;
+
+            let mut new_addresses = Vec::with_capacity(num_new_addresses);
+            new_addresses.resize_with(num_new_addresses, Pubkey::new_unique);
+            let instruction = extend_lookup_table(
+                lookup_table_address,
+                authority.pubkey(),
+                Some(context.payer.pubkey()),
+                new_addresses.clone(),
+            );
+
+            let mut expected_addresses: Vec<Pubkey> = lookup_table.addresses.to_vec();
+            expected_addresses.extend(new_addresses);
+
+            let expected_result = expected_result.map(|_| {
+                let expected_data_len =
+                    lookup_table_account.data().len() + num_new_addresses * PUBKEY_BYTES;
+                let expected_lamports = rent.minimum_balance(expected_data_len);
+                let expected_lookup_table = AddressLookupTable {
+                    meta: LookupTableMeta {
+                        last_extended_slot: current_bank_slot,
+                        last_extended_slot_start_index: if extend_same_slot {
+                            0u8
+                        } else {
+                            num_existing_addresses as u8
+                        },
+                        deactivation_slot: lookup_table.meta.deactivation_slot,
+                        authority: lookup_table.meta.authority,
+                        _padding: 0u16,
+                    },
+                    addresses: Cow::Owned(expected_addresses),
+                };
+                ExpectedTableAccount {
+                    lamports: expected_lamports,
+                    data_len: expected_data_len,
+                    state: expected_lookup_table,
+                }
+            });
+
+            let test_case = TestCase {
+                lookup_table_address,
+                instruction,
+                extra_signer: Some(&authority),
+                expected_result,
+            };
+
+            run_test_case(&mut context, test_case).await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_extend_lookup_table_with_wrong_authority() {
+    let mut context = setup_test_context().await;
+
+    let authority = Keypair::new();
+    let wrong_authority = Keypair::new();
+    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 0);
+    let lookup_table_address = Pubkey::new_unique();
+    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+
+    let new_addresses = vec![Pubkey::new_unique()];
+    let ix = extend_lookup_table(
+        lookup_table_address,
+        wrong_authority.pubkey(),
+        Some(context.payer.pubkey()),
+        new_addresses,
+    );
+
+    assert_ix_error(
+        &mut context,
+        ix,
+        Some(&wrong_authority),
+        // [Core BPF]: TODO: Should be `ProgramError::Immutable`
+        // See https://github.com/solana-labs/solana/pull/35113
+        // InstructionError::IncorrectAuthority,
+        InstructionError::Custom(0),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_extend_lookup_table_without_signing() {
+    let mut context = setup_test_context().await;
+
+    let authority = Keypair::new();
+    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
+    let lookup_table_address = Pubkey::new_unique();
+    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+
+    let new_addresses = vec![Pubkey::new_unique()];
+    let mut ix = extend_lookup_table(
+        lookup_table_address,
+        authority.pubkey(),
+        Some(context.payer.pubkey()),
+        new_addresses,
+    );
+    ix.accounts[1].is_signer = false;
+
+    assert_ix_error(
+        &mut context,
+        ix,
+        None,
+        InstructionError::MissingRequiredSignature,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_extend_deactivated_lookup_table() {
+    let mut context = setup_test_context().await;
+
+    let authority = Keypair::new();
+    let initialized_table = {
+        let mut table = new_address_lookup_table(Some(authority.pubkey()), 0);
+        table.meta.deactivation_slot = 0;
+        table
+    };
+    let lookup_table_address = Pubkey::new_unique();
+    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+
+    let new_addresses = vec![Pubkey::new_unique()];
+    let ix = extend_lookup_table(
+        lookup_table_address,
+        authority.pubkey(),
+        Some(context.payer.pubkey()),
+        new_addresses,
+    );
+
+    assert_ix_error(
+        &mut context,
+        ix,
+        Some(&authority),
+        InstructionError::InvalidArgument,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_extend_immutable_lookup_table() {
+    let mut context = setup_test_context().await;
+
+    let authority = Keypair::new();
+    let initialized_table = new_address_lookup_table(None, 1);
+    let lookup_table_address = Pubkey::new_unique();
+    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+
+    let new_addresses = vec![Pubkey::new_unique()];
+    let ix = extend_lookup_table(
+        lookup_table_address,
+        authority.pubkey(),
+        Some(context.payer.pubkey()),
+        new_addresses,
+    );
+
+    assert_ix_error(
+        &mut context,
+        ix,
+        Some(&authority),
+        // [Core BPF]: TODO: Should be `ProgramError::Immutable`
+        // See https://github.com/solana-labs/solana/pull/35113
+        // InstructionError::Immutable,
+        InstructionError::Custom(0),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_extend_lookup_table_without_payer() {
+    let mut context = setup_test_context().await;
+
+    let authority = Keypair::new();
+    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 0);
+    let lookup_table_address = Pubkey::new_unique();
+    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+
+    let new_addresses = vec![Pubkey::new_unique()];
+    let ix = extend_lookup_table(
+        lookup_table_address,
+        authority.pubkey(),
+        None,
+        new_addresses,
+    );
+
+    assert_ix_error(
+        &mut context,
+        ix,
+        Some(&authority),
+        InstructionError::NotEnoughAccountKeys,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_extend_prepaid_lookup_table_without_payer() {
+    let mut context = setup_test_context().await;
+
+    let authority = Keypair::new();
+    let lookup_table_address = Pubkey::new_unique();
+
+    let expected_state = {
+        // initialize lookup table
+        let empty_lookup_table = new_address_lookup_table(Some(authority.pubkey()), 0);
+        let mut lookup_table_account =
+            add_lookup_table_account(&mut context, lookup_table_address, empty_lookup_table).await;
+
+        // calculate required rent exempt balance for adding one address
+        let mut temp_lookup_table = new_address_lookup_table(Some(authority.pubkey()), 1);
+        let data = temp_lookup_table.clone().serialize_for_tests().unwrap();
+        let rent = context.banks_client.get_rent().await.unwrap();
+        let rent_exempt_balance = rent.minimum_balance(data.len());
+
+        // prepay for one address
+        lookup_table_account.set_lamports(rent_exempt_balance);
+        context.set_account(&lookup_table_address, &lookup_table_account);
+
+        // test will extend table in the current bank's slot
+        let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
+        temp_lookup_table.meta.last_extended_slot = clock.slot;
+
+        ExpectedTableAccount {
+            lamports: rent_exempt_balance,
+            data_len: data.len(),
+            state: temp_lookup_table,
+        }
+    };
+
+    let new_addresses = expected_state.state.addresses.to_vec();
+    let instruction = extend_lookup_table(
+        lookup_table_address,
+        authority.pubkey(),
+        None,
+        new_addresses,
+    );
+
+    run_test_case(
+        &mut context,
+        TestCase {
+            lookup_table_address,
+            instruction,
+            extra_signer: Some(&authority),
+            expected_result: Ok(expected_state),
+        },
+    )
+    .await;
+}

--- a/program/tests/extend_lookup_table_ix.rs
+++ b/program/tests/extend_lookup_table_ix.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "test-sbf")]
 
 use {
-    assert_matches::assert_matches,
     common::{
         add_lookup_table_account, assert_ix_error, new_address_lookup_table, setup_test_context,
     },
@@ -57,7 +56,7 @@ async fn run_test_case(context: &mut ProgramTestContext, test_case: TestCase<'_>
 
     match test_case.expected_result {
         Ok(expected_account) => {
-            assert_matches!(process_result, Ok(()));
+            assert!(matches!(process_result, Ok(())));
 
             let table_account = client
                 .get_account(test_case.lookup_table_address)

--- a/program/tests/extend_lookup_table_ix.rs
+++ b/program/tests/extend_lookup_table_ix.rs
@@ -91,11 +91,15 @@ async fn test_extend_lookup_table() {
             (0, 0, Err(InstructionError::InvalidInstructionData)),
             (0, 1, Ok(())),
             (0, 10, Ok(())),
+            (0, 38, Ok(())), // Max new addresses allowed by `limited_deserialize`
+            (0, 39, Err(InstructionError::InvalidInstructionData)),
             (1, 1, Ok(())),
             (1, 10, Ok(())),
-            (255, 1, Ok(())),
-            (255, 2, Err(InstructionError::InvalidInstructionData)),
+            (218, 38, Ok(())), // 38 less than maximum, 38 brings it to the maximum
+            (219, 38, Err(InstructionError::InvalidInstructionData)),
             (246, 10, Ok(())),
+            (255, 1, Ok(())), // One less than maximum, 1 brings it to the maximum
+            (255, 2, Err(InstructionError::InvalidInstructionData)),
             (256, 1, Err(InstructionError::InvalidArgument)),
         ] {
             let mut lookup_table =

--- a/program/tests/freeze_lookup_table_ix.rs
+++ b/program/tests/freeze_lookup_table_ix.rs
@@ -1,0 +1,171 @@
+#![cfg(feature = "test-sbf")]
+
+use {
+    assert_matches::assert_matches,
+    common::{
+        add_lookup_table_account, assert_ix_error, new_address_lookup_table, setup_test_context,
+    },
+    scbpf_address_lookup_table::{instruction::freeze_lookup_table, state::AddressLookupTable},
+    solana_program_test::*,
+    solana_sdk::{
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
+};
+
+mod common;
+
+#[tokio::test]
+async fn test_freeze_lookup_table() {
+    let mut context = setup_test_context().await;
+
+    let authority = Keypair::new();
+    let mut initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
+    let lookup_table_address = Pubkey::new_unique();
+    add_lookup_table_account(
+        &mut context,
+        lookup_table_address,
+        initialized_table.clone(),
+    )
+    .await;
+
+    let client = &mut context.banks_client;
+    let payer = &context.payer;
+    let recent_blockhash = context.last_blockhash;
+    let transaction = Transaction::new_signed_with_payer(
+        &[freeze_lookup_table(
+            lookup_table_address,
+            authority.pubkey(),
+        )],
+        Some(&payer.pubkey()),
+        &[payer, &authority],
+        recent_blockhash,
+    );
+
+    assert_matches!(client.process_transaction(transaction).await, Ok(()));
+    let table_account = client
+        .get_account(lookup_table_address)
+        .await
+        .unwrap()
+        .unwrap();
+    let lookup_table = AddressLookupTable::deserialize(&table_account.data).unwrap();
+    assert_eq!(lookup_table.meta.authority, None);
+
+    // Check that only the authority changed
+    initialized_table.meta.authority = None;
+    assert_eq!(initialized_table, lookup_table);
+}
+
+#[tokio::test]
+async fn test_freeze_immutable_lookup_table() {
+    let mut context = setup_test_context().await;
+
+    let initialized_table = new_address_lookup_table(None, 10);
+    let lookup_table_address = Pubkey::new_unique();
+    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+
+    let authority = Keypair::new();
+    let ix = freeze_lookup_table(lookup_table_address, authority.pubkey());
+
+    assert_ix_error(
+        &mut context,
+        ix,
+        Some(&authority),
+        // [Core BPF]: TODO: Should be `ProgramError::Immutable`
+        // See https://github.com/solana-labs/solana/pull/35113
+        // InstructionError::Immutable,
+        InstructionError::Custom(0),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_freeze_deactivated_lookup_table() {
+    let mut context = setup_test_context().await;
+
+    let authority = Keypair::new();
+    let initialized_table = {
+        let mut table = new_address_lookup_table(Some(authority.pubkey()), 10);
+        table.meta.deactivation_slot = 0;
+        table
+    };
+    let lookup_table_address = Pubkey::new_unique();
+    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+
+    let ix = freeze_lookup_table(lookup_table_address, authority.pubkey());
+
+    assert_ix_error(
+        &mut context,
+        ix,
+        Some(&authority),
+        InstructionError::InvalidArgument,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_freeze_lookup_table_with_wrong_authority() {
+    let mut context = setup_test_context().await;
+
+    let authority = Keypair::new();
+    let wrong_authority = Keypair::new();
+    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
+    let lookup_table_address = Pubkey::new_unique();
+    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+
+    let ix = freeze_lookup_table(lookup_table_address, wrong_authority.pubkey());
+
+    assert_ix_error(
+        &mut context,
+        ix,
+        Some(&wrong_authority),
+        // [Core BPF]: TODO: Should be `ProgramError::Immutable`
+        // See https://github.com/solana-labs/solana/pull/35113
+        // InstructionError::IncorrectAuthority,
+        InstructionError::Custom(0),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_freeze_lookup_table_without_signing() {
+    let mut context = setup_test_context().await;
+
+    let authority = Keypair::new();
+    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
+    let lookup_table_address = Pubkey::new_unique();
+    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+
+    let mut ix = freeze_lookup_table(lookup_table_address, authority.pubkey());
+    ix.accounts[1].is_signer = false;
+
+    assert_ix_error(
+        &mut context,
+        ix,
+        None,
+        InstructionError::MissingRequiredSignature,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_freeze_empty_lookup_table() {
+    let mut context = setup_test_context().await;
+
+    let authority = Keypair::new();
+    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 0);
+    let lookup_table_address = Pubkey::new_unique();
+    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+
+    let ix = freeze_lookup_table(lookup_table_address, authority.pubkey());
+
+    assert_ix_error(
+        &mut context,
+        ix,
+        Some(&authority),
+        InstructionError::InvalidInstructionData,
+    )
+    .await;
+}

--- a/program/tests/freeze_lookup_table_ix.rs
+++ b/program/tests/freeze_lookup_table_ix.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "test-sbf")]
 
 use {
-    assert_matches::assert_matches,
     common::{
         add_lookup_table_account, assert_ix_error, new_address_lookup_table, setup_test_context,
     },
@@ -44,7 +43,10 @@ async fn test_freeze_lookup_table() {
         recent_blockhash,
     );
 
-    assert_matches!(client.process_transaction(transaction).await, Ok(()));
+    assert!(matches!(
+        client.process_transaction(transaction).await,
+        Ok(())
+    ));
     let table_account = client
         .get_account(lookup_table_address)
         .await


### PR DESCRIPTION
This PR adds the program tests for the Core BPF implementation. They're pretty
much exactly the same as the original tests, with the feature-gated tests
removed.
