### PR TITLE
Rewrite tests with Mollusk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2211,6 +2211,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mollusk-svm"
+version = "0.0.1"
+source = "git+https://github.com/buffalojoec/mollusk.git#e64c3cf2915ebb2ef2785f19b1277ed899fe7e78"
+dependencies = [
+ "bincode",
+ "solana-bpf-loader-program",
+ "solana-logger",
+ "solana-program-runtime",
+ "solana-sdk",
+ "solana-system-program",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3109,9 +3122,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring 0.17.8",
@@ -3472,9 +3485,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
@@ -3488,9 +3501,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e769cfd7410944d41208631c6c69f8d7a8fa92cc5af85593ce7c6984375c6335"
+checksum = "4973213a11c2e1b924b36e0c6688682b5aa4623f8d4eeaa1204c32cee524e6d6"
 dependencies = [
  "Inflector",
  "base64 0.21.7",
@@ -3513,9 +3526,9 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8aea3c64f91093b555b0199aaf5016ff979d656595d62285411a6e4fab180c"
+checksum = "74c06263320e399af20d46c8cebea7a1d5dc1bc56f31f8dfaacf7119576c48a7"
 dependencies = [
  "arrayref",
  "bincode",
@@ -3579,6 +3592,7 @@ dependencies = [
  "bincode",
  "bytemuck",
  "log",
+ "mollusk-svm",
  "rustc_version",
  "serde",
  "solana-frozen-abi",
@@ -3592,9 +3606,9 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb6075bb240c4032904f300225f0a4b94afc734ff0240b3293c2ee5d13d459e5"
+checksum = "f4e57cb8f2e90361280b246f70bb7f5f86f4e4ff1ad5bbdfe18a81bea141f03a"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -3613,9 +3627,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55f7713e70cb0d0ff6bd7fb7ec4b560be6946250f65d38926da37e70a760361"
+checksum = "7c65a9540370523f3ade7190526309337cc50f1d742b3341dfa7357da3f59a56"
 dependencies = [
  "borsh 1.3.1",
  "futures",
@@ -3630,9 +3644,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b438292bd29970cb90dad49de868ca221ef809c26e858eaa1ec82406cd7af378"
+checksum = "62b1dc20a7a71cf37bcbc2a3a5dfd73d7410a13850aa68d954a9c09e6a77e652"
 dependencies = [
  "serde",
  "solana-sdk",
@@ -3641,9 +3655,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714ed74f4f62de24a09b73c639483f13114a4d94f589b8cab4fdd1c20257bb96"
+checksum = "d449d55d3c5c3fe4c9f0c9f790a9feabe294f8ff0b4c6b771a20b2313ad8974a"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -3661,9 +3675,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7726e6076303a1bb0b0b77e413364a1abaa7d4e0e9a1656d38ce8fe688a474"
+checksum = "6b1a55b8533f2dc716602e7c1b2bd555d5ac598ef6e80d28a517e6f31baf042e"
 dependencies = [
  "bincode",
  "byteorder",
@@ -3680,9 +3694,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c8c4aceb409525d309b92379ca34533bcbb2f1c1ecd7b73c702eeadd537361"
+checksum = "fda213af7ae26ce249120f211060d2a85d87fe367c6490ee19b70845cbd320fc"
 dependencies = [
  "bv",
  "bytemuck",
@@ -3698,9 +3712,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5cdcbc655b99c18cf86a17a6080de9fc7370ea3824d26ef0d174e903eccfe9a"
+checksum = "909f4553d0b31bb5b97533a6b64cc321a4eace9112d6efbabcf4408ea1b3f1db"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -3715,9 +3729,9 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80529b6cf2be6337ab4711bb0f7f2b5618301b6f14698d670215a51e5944cb17"
+checksum = "c5cc431df6cc1dd964134fa4ec7df765d3af3fae9c2148f96a3c4fb500290633"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3765,9 +3779,9 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c4af6aa0e90a9ff0b8f19e83cef431d6c0bfa54669994f1cc3144d1ca3c7b7"
+checksum = "9eb36ef3c3a1f38515c1ae0d255c4d6e5e635a856ac2aa1cd5f892b3db58e857"
 dependencies = [
  "solana-program-runtime",
  "solana-sdk",
@@ -3775,9 +3789,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d61ec5e55f26061a56fd4bf6484c5fa1a9a8a3d3b2188b4983369df2a564a70"
+checksum = "e38b040d3a42e8f7d80c4a86bb0d49d7aed663b56b0fe0ae135d2d145fb7ae3a"
 dependencies = [
  "bincode",
  "chrono",
@@ -3789,9 +3803,9 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "370c11d0787f203231c4a28972f55826fe38175c8961e240001a3a3de24d17e3"
+checksum = "ae02622c63943485f0af3d0896626eaf6478e734f0b6bc61c7cc5320963c6e75"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3811,14 +3825,14 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da8799210bc09b8116784c9d1f5e40cc3eca15c55c9ce6c509fd58fc588efa0"
+checksum = "838532d8437d00958621d2589d6033e9c69ea95cd0936efa8964146e49dcff53"
 dependencies = [
  "lazy_static",
  "log",
  "rustc_version",
- "solana-address-lookup-table-program 1.18.4",
+ "solana-address-lookup-table-program 1.18.17",
  "solana-bpf-loader-program",
  "solana-compute-budget-program",
  "solana-config-program",
@@ -3835,9 +3849,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e608aeeb42922e803589258af0028e2c9e70fbfb04e1f1ff6c5f07019c2af95"
+checksum = "4867f66e9527fa44451c861c1dc6d9b2a7c7a668d7c6a297cdefbe39f4395b33"
 dependencies = [
  "block-buffer 0.10.4",
  "bs58",
@@ -3860,9 +3874,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc7a55ad8a177287f3abb1be371b2a252d4c474d71c2e3983a7dff7db15d3f2"
+checksum = "168f24d97347b85f05192df58d6be3e3047a4aadc4001bc1b9e711a5ec878eea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3872,9 +3886,9 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4b98f4b62ecb3a095d98e7de534befa1aa3214e1702c5346b7cfaa30af05479"
+checksum = "98c426482234b7c267a5e0dfa8198442e1ffad2ad6c521f6b810949bc2719215"
 dependencies = [
  "log",
  "solana-measure",
@@ -3885,9 +3899,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f507f00c12d7309475fde8bfc58502ed87bd4024769760223cc9c03dd5aa53"
+checksum = "a0511082fc62f2d086520fff5aa1917c389d8c840930c08ad255ae05952c08a2"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -3896,9 +3910,9 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9671ea55a8613da1fa3bfcbf211cc19881b08097db2a6b6c188579c4bb82c660"
+checksum = "be55a3df105431d25f86f2a7da0cbbde5f54c1f0782ca59367ea4a8037bc6797"
 dependencies = [
  "log",
  "solana-sdk",
@@ -3906,9 +3920,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f136e251c6eb16898947d6128cd3fbc5aa4b25362f1537cb00e0987123dd495"
+checksum = "ddec097ed7572804389195128dbd57958b427829153c6cd8ec3343c86fe3cd22"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -3921,9 +3935,9 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c3bf1d905b81cdf4e0a9c81448ddd777367c9e3227025ed8f1a1aa9b417fc0"
+checksum = "258fa7c29fb7605b8d2ed89aa0d43c640d14f4147ad1f5b3fdad19a1ac145ca5"
 dependencies = [
  "bincode",
  "clap 3.2.25",
@@ -3949,9 +3963,9 @@ checksum = "8b8a731ed60e89177c8a7ab05fe0f1511cedd3e70e773f288f9de33a9cfdc21e"
 
 [[package]]
 name = "solana-perf"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330eba34f8d5e711453f7ba28382898e27353cac43b0e9b47113a1d3b3acfd73"
+checksum = "ca422edcf16a6e64003ca118575ea641f7b750f14a0ad28c71dd84f33dcb912a"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -3978,9 +3992,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fad730d66a6f33ef5bb180def74a3d84e7487b829a8f67ff58570332481f6c"
+checksum = "2bc5a636dc75e5c25651e34f7a36afc9ae60d38166687c5b0375abb580ac81a2"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -4033,9 +4047,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea72e967256cbeb1279b7e83bdee17fa9ff641676dde07e34a98842d1d9562d"
+checksum = "bf373c3da0387f47fee4c5ed2465a9628b9db026a62211a692a9285aa9251544"
 dependencies = [
  "base64 0.21.7",
  "bincode",
@@ -4061,9 +4075,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "156d6d6481aa9dff903d3d6a8b4491e14eb92dafad34e3fc151ce7bf89f65275"
+checksum = "9194b8744c5b135401ab4a2923a1072d3a67697bd50f7450a4ed5302f36a6999"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4091,9 +4105,9 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c001d326505e0ad178db0b3b81e81b9d0a3247d5582fa3818c563352d8b401"
+checksum = "97b9abc76168d19927561db6a3685b98752bd0961b4ce4f8b7f85ee12238c017"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -4116,9 +4130,9 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60019bc9e7817ddef328ad7ffb0c3a5ea63e2afcbee4897bff1e7a1fd1e1a55a"
+checksum = "7952c5306a0be5f5276448cd20246b31265bfa884f29a077a24303c6a16aeb34"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -4143,9 +4157,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "652cd60beb6e0006c4b5c7b449b0593e09e8340966414eff9b30543aeae4c761"
+checksum = "a4fa0cc66f8e73d769bca2ede3012ba2ef8ab67963e832808665369f2cf81743"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -4153,9 +4167,9 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed53b5cf416c93a9f233ee95c6c2242941de8a606230262a16ca650b2bc519d5"
+checksum = "289803796d4ff7b4699504d3ab9e9d9c5205ea3892b2ebe397b377494dbd75d4"
 dependencies = [
  "console",
  "dialoguer",
@@ -4172,9 +4186,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03ef7807e31203d07aa9f3baf76d8f98d9ded2e88aab9044f42a5c068e19b1e"
+checksum = "6cb55a08018776a62ecff52139fbcdab1a7baa4e8f077202be58156e8dde4d5f"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -4198,9 +4212,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5d71639e7600d23558f29414772f20334af5ce0d1977aaac09b5d23e2b06a1"
+checksum = "72a8403038f4d6ab65bc7e7afb3afe8d9824c592232553c5cef55cf3de36025d"
 dependencies = [
  "base64 0.21.7",
  "bs58",
@@ -4220,9 +4234,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf7e20e6b3874a8da9db9b50db917b868797b5841776b269184deb2f521296a"
+checksum = "4caca735caf76d51c074c3bacbfe38094bf7f92cfbe7b5b13f3bc4946e64f889"
 dependencies = [
  "clap 2.34.0",
  "solana-clap-utils",
@@ -4233,9 +4247,9 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed0bcf3d8c1c16f2efcb6baaa6142cdc727e411853d0f4dc151986c771a6f7e"
+checksum = "b699943045665038bfa4e76dd2582b4c390f1aec6ab5edef36da43afe3469f1d"
 dependencies = [
  "aquamarine",
  "arrayref",
@@ -4276,7 +4290,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-accounts-db",
- "solana-address-lookup-table-program 1.18.4",
+ "solana-address-lookup-table-program 1.18.17",
  "solana-bpf-loader-program",
  "solana-bucket-map",
  "solana-compute-budget-program",
@@ -4310,9 +4324,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3612d0b4c2120c2a4cef6bac8af469908575319249e1a5c0de5a487fb7610f"
+checksum = "df43d3a1e1637397ab43cbc216a5a8f977ec8a3cc3f3ae8c3851c83a3255dbcf"
 dependencies = [
  "assert_matches",
  "base64 0.21.7",
@@ -4365,9 +4379,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df952c230e35ba179882cef765655b171b8f99f512f04fc4a84800fa43cfe592"
+checksum = "86c76414183a325038ff020b22c07d1e9d2da0703ddc0244acfed37ee2921d96"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -4384,9 +4398,9 @@ checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4f35f70cc7cbe9261fbca4a8952a0947fb2874159dec349b8b4762ead4b422"
+checksum = "e056d865d22548bb7228121e118aa632486fc1a33a100961e5e98b5663371384"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -4400,9 +4414,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418e9f40857d29a2d70d16d8a93ccc4b537ed6dc91a074fd4885c5759c55f2f"
+checksum = "c5dd1bc07beb75da5df5e07301d3d0d6104872c9afade22b910af9061fb4bc15"
 dependencies = [
  "bincode",
  "log",
@@ -4415,9 +4429,9 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a852027d8b095aaf6931cab230562118bdf71e0b38a17d073f9a808aebcba9"
+checksum = "fad1bdb955ec6d23a1dbf87e403ff3e610d68616275693125a893d7ed4b2d323"
 dependencies = [
  "async-channel",
  "bytes",
@@ -4437,6 +4451,7 @@ dependencies = [
  "rand 0.8.5",
  "rcgen",
  "rustls",
+ "smallvec",
  "solana-metrics",
  "solana-perf",
  "solana-sdk",
@@ -4447,9 +4462,9 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7aa11391924deb56698df62b791659535d4959cbb3456cd7ad06f6cd0d9839"
+checksum = "78733745268c96d5a29c09cde9f0a6c9d662abba43e661b75dd858da8e3d0b2e"
 dependencies = [
  "bincode",
  "log",
@@ -4461,9 +4476,9 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104cda4f0cc977db2474728413253a35bd283492546d57bfcc6eddb2f9432a4a"
+checksum = "bc301310ba0755c449a8800136f67f8ad14419b366404629894cd10021495360"
 dependencies = [
  "bincode",
  "log",
@@ -4476,9 +4491,9 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0c2cd930f1ef2ced8f73d67543d04ab69f6f0b4b0733e8ef4c973022c0a9dc"
+checksum = "fb887bd5078ff015e103e9ee54a6713380590efa8ff1804b3a653f07188928c6"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4500,9 +4515,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e7fed91baf079b21ea8b9a70ab61910f2a539e6d08740f0f6f6c1f90784472b"
+checksum = "4a0cdfdf63192fb60de094fae8e81159e4e3e9aac9659fe3f9ef0e707023fb32"
 dependencies = [
  "Inflector",
  "base64 0.21.7",
@@ -4525,9 +4540,9 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0fa2c7d277206afcad3e13472379cf7e7c804d02de0fb0bd61730a72df1fef"
+checksum = "3ea0d6d8d66e36371577f51c4d1d6192a66f1fa4efe7161a36d94677640dcadb"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -4540,9 +4555,9 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30194d1b6a9311f9d92e68fd4355e075169fbc19794e3cef19b45829fa83c0bd"
+checksum = "6f4c2f531c22ce806b211118be8928a791425f97de4592371fb57b246ed33e34"
 dependencies = [
  "log",
  "rustc_version",
@@ -4556,9 +4571,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fda223d608463c5c65f179b294c2508ffe36999d8ad42422752b824d7da6c1"
+checksum = "28ab95a5d19ff0464def1777adaae5a74e1edc9e6818103064c18fdc2643f6cb"
 dependencies = [
  "crossbeam-channel",
  "itertools",
@@ -4575,9 +4590,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2880e99200ac244ffd63ff7b978f989d9b42a16d2639dce0bf7db1f029c07050"
+checksum = "6d8a6486017e71a3714a8e1a635e17209135cc20535ba9808ccf106d80ff6e8b"
 dependencies = [
  "bincode",
  "log",
@@ -4597,9 +4612,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4bba72e165175cccc749755026d23d7e406e29ae1df16b2e43722c749f5beb7"
+checksum = "f1e3dfb2deb449f7eb1dbd0c7e66dd95ec7b1303a5788673f9fbc9b5a5ea59f2"
 dependencies = [
  "bytemuck",
  "num-derive 0.4.2",
@@ -4611,9 +4626,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.18.4"
+version = "1.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd13a3e898ab98d3a3cb781935f2d0298ba85d11d589b82be5537d6498bf42d"
+checksum = "513407f88394e437b4ff5aad892bc5bf51a655ae2401e6e63549734d3695c46f"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.21.7",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -26,6 +26,7 @@ solana-program = "1.18.2"
 spl-program-error = "0.4.0"
 
 [dev-dependencies]
+mollusk-svm = { git = "https://github.com/buffalojoec/mollusk.git" }
 solana-program-test = "1.18.2"
 solana-sdk = "1.18.2"
 test-case = "3.3.1"

--- a/program/tests/common.rs
+++ b/program/tests/common.rs
@@ -2,17 +2,26 @@
 #![cfg(feature = "test-sbf")]
 
 use {
+    mollusk_svm::Mollusk,
     solana_address_lookup_table_program::state::{AddressLookupTable, LookupTableMeta},
     solana_program_test::*,
     solana_sdk::{
         account::AccountSharedData,
         instruction::{Instruction, InstructionError},
         pubkey::Pubkey,
+        rent::Rent,
         signature::{Keypair, Signer},
         transaction::{Transaction, TransactionError},
     },
     std::borrow::Cow,
 };
+
+pub fn setup() -> Mollusk {
+    Mollusk::new(
+        &solana_address_lookup_table_program::id(),
+        "solana_address_lookup_table_program",
+    )
+}
 
 pub async fn setup_test_context() -> ProgramTestContext {
     let mut program_test = ProgramTest::default();
@@ -70,6 +79,20 @@ pub fn new_address_lookup_table(
         },
         addresses: Cow::Owned(addresses),
     }
+}
+
+pub fn lookup_table_account(
+    address_lookup_table: AddressLookupTable<'static>,
+) -> AccountSharedData {
+    let data = address_lookup_table.serialize_for_tests().unwrap();
+    let rent_exempt_balance = Rent::default().minimum_balance(data.len());
+    let mut account = AccountSharedData::new(
+        rent_exempt_balance,
+        data.len(),
+        &solana_address_lookup_table_program::id(),
+    );
+    account.set_data_from_slice(&data);
+    account
 }
 
 pub async fn add_lookup_table_account(

--- a/program/tests/create_lookup_table_ix.rs
+++ b/program/tests/create_lookup_table_ix.rs
@@ -1,150 +1,168 @@
 #![cfg(feature = "test-sbf")]
 
+mod common;
+
 use {
-    common::{assert_ix_error, setup_test_context},
+    common::setup,
+    mollusk_svm::{program::system_program, result::Check},
     solana_address_lookup_table_program::{
         instruction::create_lookup_table,
         state::{AddressLookupTable, LOOKUP_TABLE_META_SIZE},
     },
-    solana_program_test::*,
     solana_sdk::{
-        clock::Slot, instruction::InstructionError, pubkey::Pubkey, rent::Rent, signature::Signer,
-        transaction::Transaction,
+        account::{AccountSharedData, ReadableAccount},
+        clock::Slot,
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        rent::Rent,
+        system_program,
     },
 };
-
-mod common;
 
 // [Core BPF]: Tests that assert proper authority checks have been removed,
 // since feature "FKAcEvNgSY79RpqsPNUV5gDyumopH4cEHqUxyfm8b8Ap"
 // (relax_authority_signer_check_for_lookup_table_creation) has been activated
 // on all clusters.
 
-#[tokio::test]
-async fn test_create_lookup_table_idempotent() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_create_lookup_table_idempotent() {
+    let mut mollusk = setup();
 
     let test_recent_slot = 123;
-    // [Core BPF]: Warping to slot instead of overwriting `SlotHashes`.
-    context.warp_to_slot(test_recent_slot + 1).unwrap();
 
-    let client = &mut context.banks_client;
-    let payer = &context.payer;
-    let recent_blockhash = context.last_blockhash;
-    let authority_address = Pubkey::new_unique();
+    // [Core BPF]: Warping to slot instead of overwriting `SlotHashes`.
+    mollusk.warp_to_slot(test_recent_slot + 1);
+
+    let payer = Pubkey::new_unique();
+    let authority = Pubkey::new_unique();
     let (create_lookup_table_ix, lookup_table_address) =
-        create_lookup_table(authority_address, payer.pubkey(), test_recent_slot);
+        create_lookup_table(authority, payer, test_recent_slot);
 
     // First create should succeed
-    {
-        let transaction = Transaction::new_signed_with_payer(
-            &[create_lookup_table_ix.clone()],
-            Some(&payer.pubkey()),
-            &[payer],
-            recent_blockhash,
-        );
-
-        assert!(matches!(
-            client.process_transaction(transaction).await,
-            Ok(())
-        ));
-        let lookup_table_account = client
-            .get_account(lookup_table_address)
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            lookup_table_account.owner,
-            solana_address_lookup_table_program::id()
-        );
-        assert_eq!(lookup_table_account.data.len(), LOOKUP_TABLE_META_SIZE);
-        assert_eq!(
-            lookup_table_account.lamports,
-            Rent::default().minimum_balance(LOOKUP_TABLE_META_SIZE)
-        );
-        let lookup_table = AddressLookupTable::deserialize(&lookup_table_account.data).unwrap();
-        assert_eq!(lookup_table.meta.deactivation_slot, Slot::MAX);
-        assert_eq!(lookup_table.meta.authority, Some(authority_address));
-        assert_eq!(lookup_table.meta.last_extended_slot, 0);
-        assert_eq!(lookup_table.meta.last_extended_slot_start_index, 0);
-        assert_eq!(lookup_table.addresses.len(), 0);
-    }
-
-    // Second create should succeed too
-    {
-        let recent_blockhash = client
-            .get_new_latest_blockhash(&recent_blockhash)
-            .await
-            .unwrap();
-        let transaction = Transaction::new_signed_with_payer(
-            &[create_lookup_table_ix],
-            Some(&payer.pubkey()),
-            &[payer],
-            recent_blockhash,
-        );
-
-        assert!(matches!(
-            client.process_transaction(transaction).await,
-            Ok(())
-        ));
-    }
-}
-
-#[tokio::test]
-async fn test_create_lookup_table_use_payer_as_authority() {
-    let mut context = setup_test_context().await;
-
-    let test_recent_slot = 123;
-    // [Core BPF]: Warping to slot instead of overwriting `SlotHashes`.
-    context.warp_to_slot(test_recent_slot + 1).unwrap();
-
-    let client = &mut context.banks_client;
-    let payer = &context.payer;
-    let recent_blockhash = context.last_blockhash;
-    let authority_address = payer.pubkey();
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_lookup_table(authority_address, payer.pubkey(), test_recent_slot).0],
-        Some(&payer.pubkey()),
-        &[payer],
-        recent_blockhash,
+    let result = mollusk.process_and_validate_instruction(
+        &create_lookup_table_ix,
+        &[
+            (lookup_table_address, AccountSharedData::default()),
+            (authority, AccountSharedData::default()),
+            (
+                payer,
+                AccountSharedData::new(100_000_000, 0, &system_program::id()),
+            ),
+            system_program(),
+        ],
+        &[Check::success()],
     );
 
-    assert!(matches!(
-        client.process_transaction(transaction).await,
-        Ok(())
-    ));
+    let lookup_table_account = result.get_account(&lookup_table_address).unwrap();
+
+    assert_eq!(
+        lookup_table_account.owner(),
+        &solana_address_lookup_table_program::id()
+    );
+    assert_eq!(lookup_table_account.data().len(), LOOKUP_TABLE_META_SIZE);
+    assert_eq!(
+        lookup_table_account.lamports(),
+        Rent::default().minimum_balance(LOOKUP_TABLE_META_SIZE)
+    );
+    let lookup_table = AddressLookupTable::deserialize(&lookup_table_account.data()).unwrap();
+    assert_eq!(lookup_table.meta.deactivation_slot, Slot::MAX);
+    assert_eq!(lookup_table.meta.authority, Some(authority));
+    assert_eq!(lookup_table.meta.last_extended_slot, 0);
+    assert_eq!(lookup_table.meta.last_extended_slot_start_index, 0);
+    assert_eq!(lookup_table.addresses.len(), 0);
+
+    // Second create should succeed too
+    mollusk.process_and_validate_instruction(
+        &create_lookup_table_ix,
+        &[
+            (lookup_table_address, lookup_table_account.clone()),
+            (authority, AccountSharedData::default()),
+            (payer, AccountSharedData::default()), // Note the lack of lamports.
+            system_program(),
+        ],
+        &[Check::success()],
+    );
 }
 
-#[tokio::test]
-async fn test_create_lookup_table_not_recent_slot() {
-    let mut context = setup_test_context().await;
-    let payer = &context.payer;
-    let authority_address = Pubkey::new_unique();
-
-    let ix = create_lookup_table(authority_address, payer.pubkey(), Slot::MAX).0;
-
-    assert_ix_error(
-        &mut context,
-        ix,
-        None,
-        InstructionError::InvalidInstructionData,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn test_create_lookup_table_pda_mismatch() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_create_lookup_table_use_payer_as_authority() {
+    let mut mollusk = setup();
 
     let test_recent_slot = 123;
+
     // [Core BPF]: Warping to slot instead of overwriting `SlotHashes`.
-    context.warp_to_slot(test_recent_slot + 1).unwrap();
+    mollusk.warp_to_slot(test_recent_slot + 1);
 
-    let payer = &context.payer;
-    let authority_address = Pubkey::new_unique();
+    let payer = Pubkey::new_unique();
+    let authority = Pubkey::new_unique();
+    let (create_lookup_table_ix, lookup_table_address) =
+        create_lookup_table(authority, payer, test_recent_slot);
 
-    let mut ix = create_lookup_table(authority_address, payer.pubkey(), test_recent_slot).0;
-    ix.accounts[0].pubkey = Pubkey::new_unique();
+    mollusk.process_and_validate_instruction(
+        &create_lookup_table_ix,
+        &[
+            (lookup_table_address, AccountSharedData::default()),
+            (authority, AccountSharedData::default()),
+            (
+                payer,
+                AccountSharedData::new(100_000_000, 0, &system_program::id()),
+            ),
+            system_program(),
+        ],
+        &[Check::success()],
+    );
+}
 
-    assert_ix_error(&mut context, ix, None, InstructionError::InvalidArgument).await;
+#[test]
+fn test_create_lookup_table_not_recent_slot() {
+    let mollusk = setup();
+
+    let payer = Pubkey::new_unique();
+    let authority = Pubkey::new_unique();
+    let (create_lookup_table_ix, lookup_table_address) =
+        create_lookup_table(authority, payer, Slot::MAX);
+
+    mollusk.process_and_validate_instruction(
+        &create_lookup_table_ix,
+        &[
+            (lookup_table_address, AccountSharedData::default()),
+            (authority, AccountSharedData::default()),
+            (
+                payer,
+                AccountSharedData::new(100_000_000, 0, &system_program::id()),
+            ),
+            system_program(),
+        ],
+        &[Check::err(ProgramError::InvalidInstructionData)],
+    );
+}
+
+#[test]
+fn test_create_lookup_table_pda_mismatch() {
+    let mut mollusk = setup();
+
+    let test_recent_slot = 123;
+
+    // [Core BPF]: Warping to slot instead of overwriting `SlotHashes`.
+    mollusk.warp_to_slot(test_recent_slot + 1);
+
+    let payer = Pubkey::new_unique();
+    let authority = Pubkey::new_unique();
+    let wrong_pda = Pubkey::new_unique();
+    let mut create_lookup_table_ix = create_lookup_table(authority, payer, test_recent_slot).0;
+    create_lookup_table_ix.accounts[0].pubkey = wrong_pda;
+
+    mollusk.process_and_validate_instruction(
+        &create_lookup_table_ix,
+        &[
+            (wrong_pda, AccountSharedData::default()),
+            (authority, AccountSharedData::default()),
+            (
+                payer,
+                AccountSharedData::new(100_000_000, 0, &system_program::id()),
+            ),
+            system_program(),
+        ],
+        &[Check::err(ProgramError::InvalidArgument)],
+    );
 }

--- a/program/tests/deactivate_lookup_table_ix.rs
+++ b/program/tests/deactivate_lookup_table_ix.rs
@@ -1,155 +1,141 @@
 #![cfg(feature = "test-sbf")]
 
+mod common;
+
 use {
-    common::{
-        add_lookup_table_account, assert_ix_error, new_address_lookup_table, setup_test_context,
-    },
+    common::{lookup_table_account, new_address_lookup_table, setup},
+    mollusk_svm::result::Check,
     solana_address_lookup_table_program::{
         instruction::deactivate_lookup_table, state::AddressLookupTable,
     },
-    solana_program_test::*,
     solana_sdk::{
-        instruction::InstructionError,
+        account::{AccountSharedData, ReadableAccount},
+        program_error::ProgramError,
         pubkey::Pubkey,
-        signature::{Keypair, Signer},
-        transaction::Transaction,
     },
 };
 
-mod common;
+#[test]
+fn test_deactivate_lookup_table() {
+    let mollusk = setup();
 
-#[tokio::test]
-async fn test_deactivate_lookup_table() {
-    let mut context = setup_test_context().await;
+    let authority = Pubkey::new_unique();
+    let mut initialized_table = new_address_lookup_table(Some(authority), 10);
 
-    let authority = Keypair::new();
-    let mut initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(
-        &mut context,
-        lookup_table_address,
-        initialized_table.clone(),
-    )
-    .await;
+    let lookup_table_account = lookup_table_account(initialized_table.clone());
 
-    let client = &mut context.banks_client;
-    let payer = &context.payer;
-    let recent_blockhash = context.last_blockhash;
-    let transaction = Transaction::new_signed_with_payer(
-        &[deactivate_lookup_table(
-            lookup_table_address,
-            authority.pubkey(),
-        )],
-        Some(&payer.pubkey()),
-        &[payer, &authority],
-        recent_blockhash,
+    let result = mollusk.process_and_validate_instruction(
+        &deactivate_lookup_table(lookup_table_address, authority),
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+        ],
+        &[Check::success()],
     );
 
-    assert!(matches!(
-        client.process_transaction(transaction).await,
-        Ok(())
-    ));
-    let table_account = client
-        .get_account(lookup_table_address)
-        .await
-        .unwrap()
-        .unwrap();
-    let lookup_table = AddressLookupTable::deserialize(&table_account.data).unwrap();
-    assert_eq!(lookup_table.meta.deactivation_slot, 1);
+    let lookup_table_account = result.get_account(&lookup_table_address).unwrap();
+
+    let lookup_table = AddressLookupTable::deserialize(&lookup_table_account.data()).unwrap();
+    assert_eq!(lookup_table.meta.deactivation_slot, 0);
 
     // Check that only the deactivation slot changed
-    initialized_table.meta.deactivation_slot = 1;
+    initialized_table.meta.deactivation_slot = 0;
     assert_eq!(initialized_table, lookup_table);
 }
 
-#[tokio::test]
-async fn test_deactivate_immutable_lookup_table() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_deactivate_immutable_lookup_table() {
+    let mollusk = setup();
 
+    let authority = Pubkey::new_unique();
     let initialized_table = new_address_lookup_table(None, 10);
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
-    let authority = Keypair::new();
-    let ix = deactivate_lookup_table(lookup_table_address, authority.pubkey());
-
-    assert_ix_error(
-        &mut context,
-        ix,
-        Some(&authority),
-        // [Core BPF]: TODO: Should be `ProgramError::Immutable`
-        // See https://github.com/solana-labs/solana/pull/35113
-        // InstructionError::Immutable,
-        InstructionError::Custom(0),
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &deactivate_lookup_table(lookup_table_address, authority),
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+        ],
+        &[
+            // [Core BPF]: TODO: Should be `ProgramError::Immutable`
+            // See https://github.com/solana-labs/solana/pull/35113
+            Check::err(ProgramError::Custom(0)),
+        ],
+    );
 }
 
-#[tokio::test]
-async fn test_deactivate_already_deactivated() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_deactivate_already_deactivated() {
+    let mollusk = setup();
 
-    let authority = Keypair::new();
+    let authority = Pubkey::new_unique();
     let initialized_table = {
-        let mut table = new_address_lookup_table(Some(authority.pubkey()), 0);
+        let mut table = new_address_lookup_table(Some(authority), 0);
         table.meta.deactivation_slot = 0;
         table
     };
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
-    let ix = deactivate_lookup_table(lookup_table_address, authority.pubkey());
-
-    assert_ix_error(
-        &mut context,
-        ix,
-        Some(&authority),
-        InstructionError::InvalidArgument,
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &deactivate_lookup_table(lookup_table_address, authority),
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+        ],
+        &[Check::err(ProgramError::InvalidArgument)],
+    );
 }
 
-#[tokio::test]
-async fn test_deactivate_lookup_table_with_wrong_authority() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_deactivate_lookup_table_with_wrong_authority() {
+    let mollusk = setup();
 
-    let authority = Keypair::new();
-    let wrong_authority = Keypair::new();
-    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
+    let authority = Pubkey::new_unique();
+    let wrong_authority = Pubkey::new_unique();
+    let initialized_table = new_address_lookup_table(Some(authority), 10);
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
-    let ix = deactivate_lookup_table(lookup_table_address, wrong_authority.pubkey());
-
-    assert_ix_error(
-        &mut context,
-        ix,
-        Some(&wrong_authority),
-        // [Core BPF]: TODO: Should be `ProgramError::Immutable`
-        // See https://github.com/solana-labs/solana/pull/35113
-        // InstructionError::IncorrectAuthority,
-        InstructionError::Custom(0),
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &deactivate_lookup_table(lookup_table_address, wrong_authority),
+        &[
+            (lookup_table_address, lookup_table_account),
+            (wrong_authority, AccountSharedData::default()),
+        ],
+        &[
+            // [Core BPF]: TODO: Should be `ProgramError::Immutable`
+            // See https://github.com/solana-labs/solana/pull/35113
+            Check::err(ProgramError::Custom(0)),
+        ],
+    );
 }
 
-#[tokio::test]
-async fn test_deactivate_lookup_table_without_signing() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_deactivate_lookup_table_without_signing() {
+    let mollusk = setup();
 
-    let authority = Keypair::new();
-    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
+    let authority = Pubkey::new_unique();
+    let initialized_table = new_address_lookup_table(Some(authority), 10);
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
-    let mut ix = deactivate_lookup_table(lookup_table_address, authority.pubkey());
-    ix.accounts[1].is_signer = false;
+    let mut instruction = deactivate_lookup_table(lookup_table_address, authority);
+    instruction.accounts[1].is_signer = false;
 
-    assert_ix_error(
-        &mut context,
-        ix,
-        None,
-        InstructionError::MissingRequiredSignature,
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &instruction,
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+        ],
+        &[Check::err(ProgramError::MissingRequiredSignature)],
+    );
 }

--- a/program/tests/freeze_lookup_table_ix.rs
+++ b/program/tests/freeze_lookup_table_ix.rs
@@ -1,60 +1,42 @@
 #![cfg(feature = "test-sbf")]
 
+mod common;
+
 use {
-    common::{
-        add_lookup_table_account, assert_ix_error, new_address_lookup_table, setup_test_context,
-    },
+    common::{lookup_table_account, new_address_lookup_table, setup},
+    mollusk_svm::result::Check,
     solana_address_lookup_table_program::{
         instruction::freeze_lookup_table, state::AddressLookupTable,
     },
-    solana_program_test::*,
     solana_sdk::{
-        instruction::InstructionError,
+        account::{AccountSharedData, ReadableAccount},
+        program_error::ProgramError,
         pubkey::Pubkey,
-        signature::{Keypair, Signer},
-        transaction::Transaction,
     },
 };
 
-mod common;
+#[test]
+fn test_freeze_lookup_table() {
+    let mollusk = setup();
 
-#[tokio::test]
-async fn test_freeze_lookup_table() {
-    let mut context = setup_test_context().await;
+    let authority = Pubkey::new_unique();
+    let mut initialized_table = new_address_lookup_table(Some(authority), 10);
 
-    let authority = Keypair::new();
-    let mut initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(
-        &mut context,
-        lookup_table_address,
-        initialized_table.clone(),
-    )
-    .await;
+    let lookup_table_account = lookup_table_account(initialized_table.clone());
 
-    let client = &mut context.banks_client;
-    let payer = &context.payer;
-    let recent_blockhash = context.last_blockhash;
-    let transaction = Transaction::new_signed_with_payer(
-        &[freeze_lookup_table(
-            lookup_table_address,
-            authority.pubkey(),
-        )],
-        Some(&payer.pubkey()),
-        &[payer, &authority],
-        recent_blockhash,
+    let result = mollusk.process_and_validate_instruction(
+        &freeze_lookup_table(lookup_table_address, authority),
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+        ],
+        &[Check::success()],
     );
 
-    assert!(matches!(
-        client.process_transaction(transaction).await,
-        Ok(())
-    ));
-    let table_account = client
-        .get_account(lookup_table_address)
-        .await
-        .unwrap()
-        .unwrap();
-    let lookup_table = AddressLookupTable::deserialize(&table_account.data).unwrap();
+    let lookup_table_account = result.get_account(&lookup_table_address).unwrap();
+    let lookup_table = AddressLookupTable::deserialize(&lookup_table_account.data()).unwrap();
+
     assert_eq!(lookup_table.meta.authority, None);
 
     // Check that only the authority changed
@@ -62,114 +44,119 @@ async fn test_freeze_lookup_table() {
     assert_eq!(initialized_table, lookup_table);
 }
 
-#[tokio::test]
-async fn test_freeze_immutable_lookup_table() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_freeze_immutable_lookup_table() {
+    let mollusk = setup();
 
+    let authority = Pubkey::new_unique();
     let initialized_table = new_address_lookup_table(None, 10);
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
-    let authority = Keypair::new();
-    let ix = freeze_lookup_table(lookup_table_address, authority.pubkey());
-
-    assert_ix_error(
-        &mut context,
-        ix,
-        Some(&authority),
-        // [Core BPF]: TODO: Should be `ProgramError::Immutable`
-        // See https://github.com/solana-labs/solana/pull/35113
-        // InstructionError::Immutable,
-        InstructionError::Custom(0),
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &freeze_lookup_table(lookup_table_address, authority),
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+        ],
+        &[
+            // [Core BPF]: TODO: Should be `ProgramError::Immutable`
+            // See https://github.com/solana-labs/solana/pull/35113
+            Check::err(ProgramError::Custom(0)),
+        ],
+    );
 }
 
-#[tokio::test]
-async fn test_freeze_deactivated_lookup_table() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_freeze_deactivated_lookup_table() {
+    let mollusk = setup();
 
-    let authority = Keypair::new();
+    let authority = Pubkey::new_unique();
     let initialized_table = {
-        let mut table = new_address_lookup_table(Some(authority.pubkey()), 10);
+        let mut table = new_address_lookup_table(Some(authority), 10);
         table.meta.deactivation_slot = 0;
         table
     };
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
-    let ix = freeze_lookup_table(lookup_table_address, authority.pubkey());
-
-    assert_ix_error(
-        &mut context,
-        ix,
-        Some(&authority),
-        InstructionError::InvalidArgument,
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &freeze_lookup_table(lookup_table_address, authority),
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+        ],
+        &[Check::err(ProgramError::InvalidArgument)],
+    );
 }
 
-#[tokio::test]
-async fn test_freeze_lookup_table_with_wrong_authority() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_freeze_lookup_table_with_wrong_authority() {
+    let mollusk = setup();
 
-    let authority = Keypair::new();
-    let wrong_authority = Keypair::new();
-    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
+    let authority = Pubkey::new_unique();
+    let wrong_authority = Pubkey::new_unique();
+
+    let initialized_table = new_address_lookup_table(Some(authority), 10);
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
-    let ix = freeze_lookup_table(lookup_table_address, wrong_authority.pubkey());
-
-    assert_ix_error(
-        &mut context,
-        ix,
-        Some(&wrong_authority),
-        // [Core BPF]: TODO: Should be `ProgramError::Immutable`
-        // See https://github.com/solana-labs/solana/pull/35113
-        // InstructionError::IncorrectAuthority,
-        InstructionError::Custom(0),
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &freeze_lookup_table(lookup_table_address, wrong_authority),
+        &[
+            (lookup_table_address, lookup_table_account),
+            (wrong_authority, AccountSharedData::default()),
+        ],
+        &[
+            // [Core BPF]: TODO: Should be `ProgramError::IncorrectAuthority`
+            // See https://github.com/solana-labs/solana/pull/35113
+            Check::err(ProgramError::Custom(0)),
+        ],
+    );
 }
 
-#[tokio::test]
-async fn test_freeze_lookup_table_without_signing() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_freeze_lookup_table_without_signing() {
+    let mollusk = setup();
 
-    let authority = Keypair::new();
-    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
+    let authority = Pubkey::new_unique();
+    let initialized_table = new_address_lookup_table(Some(authority), 10);
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
-    let mut ix = freeze_lookup_table(lookup_table_address, authority.pubkey());
-    ix.accounts[1].is_signer = false;
+    let mut instruction = freeze_lookup_table(lookup_table_address, authority);
+    instruction.accounts[1].is_signer = false;
 
-    assert_ix_error(
-        &mut context,
-        ix,
-        None,
-        InstructionError::MissingRequiredSignature,
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &instruction,
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+        ],
+        &[Check::err(ProgramError::MissingRequiredSignature)],
+    );
 }
 
-#[tokio::test]
-async fn test_freeze_empty_lookup_table() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_freeze_empty_lookup_table() {
+    let mollusk = setup();
 
-    let authority = Keypair::new();
-    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 0);
+    let authority = Pubkey::new_unique();
+    let initialized_table = new_address_lookup_table(Some(authority), 0);
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
-    let ix = freeze_lookup_table(lookup_table_address, authority.pubkey());
-
-    assert_ix_error(
-        &mut context,
-        ix,
-        Some(&authority),
-        InstructionError::InvalidInstructionData,
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &freeze_lookup_table(lookup_table_address, authority),
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+        ],
+        &[Check::err(ProgramError::InvalidInstructionData)],
+    );
 }


### PR DESCRIPTION
This PR rewrites all program tests with Mollusk instead of `solana-program-test`.

(WIP)