### PR TITLE
Add frozen-abi feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3551,7 +3551,6 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "bytemuck",
- "log",
  "rustc_version",
  "serde",
  "solana-frozen-abi",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,15 +13,15 @@ program-id = "AddressLookupTab1e1111111111111111111111111"
 
 [features]
 bpf-entrypoint = []
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 test-sbf = []
 
 [dependencies]
 bincode = "1.3.3"
 bytemuck = "1.14.1"
-log = "0.4.20"
 serde = { version = "1.0.193", features = ["derive"] }
-solana-frozen-abi = "2.0.1"
-solana-frozen-abi-macro = "2.0.1"
+solana-frozen-abi = { version = "2.0.1", optional = true }
+solana-frozen-abi-macro = { version = "2.0.1", optional = true }
 solana-program = "2.0.1"
 spl-program-error = "0.5.0"
 

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -1,6 +1,5 @@
 //! Address Lookup Table Program
-// [Core BPF]: Required for `solana-frozen-abi-macro` to work.
-#![allow(incomplete_features)]
+
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]
 
 #[cfg(all(target_os = "solana", feature = "bpf-entrypoint"))]

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -1,7 +1,8 @@
+#[cfg(feature = "frozen-abi")]
+use solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample};
 use {
     crate::error::AddressLookupError,
     serde::{Deserialize, Serialize},
-    solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample},
     solana_program::{
         clock::Slot, program_error::ProgramError, pubkey::Pubkey, slot_hashes::MAX_ENTRIES,
     },
@@ -41,7 +42,8 @@ pub enum LookupTableStatus {
 }
 
 /// Address lookup table metadata
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct LookupTableMeta {
     // [Core BPF]: TODO: `Clock` instead of `SlotHashes`.
     /// Lookup tables cannot be closed until the deactivation slot is
@@ -131,7 +133,8 @@ impl LookupTableMeta {
 }
 
 /// Program account states
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, AbiExample, AbiEnumVisitor)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum ProgramState {
     /// Account is not initialized.
@@ -169,7 +172,8 @@ impl ProgramState {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, AbiExample)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct AddressLookupTable<'a> {
     pub meta: LookupTableMeta,
     pub addresses: Cow<'a, [Pubkey]>,


### PR DESCRIPTION
Similar to the pattern we've taken in the monorepo, place `solana-frozen-abi` trait
implementations behind a feature flag, `frozen-abi`.

Also removes the `log` dependency altogether, as of https://github.com/anza-xyz/agave/pull/153