### PR TITLE
update to use new 2.0 errors

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -161,15 +161,11 @@ fn process_freeze_lookup_table(program_id: &Pubkey, accounts: &[AccountInfo]) ->
 
         if lookup_table.meta.authority.is_none() {
             msg!("Lookup table is already frozen");
-            // [Core BPF]: TODO: Should be `ProgramError::Immutable`
-            // See https://github.com/solana-labs/solana/pull/35113
-            return Err(ProgramError::Custom(0));
+            return Err(ProgramError::Immutable);
         }
         if lookup_table.meta.authority != Some(*authority_info.key) {
             msg!("Incorrect lookup table authority");
-            // [Core BPF]: TODO: Should be `ProgramError::IncorrectAuthority`
-            // See https://github.com/solana-labs/solana/pull/35113
-            return Err(ProgramError::Custom(0));
+            return Err(ProgramError::IncorrectAuthority);
         }
         if lookup_table.meta.deactivation_slot != Slot::MAX {
             msg!("Deactivated tables cannot be frozen");
@@ -218,15 +214,11 @@ fn process_extend_lookup_table(
 
         if lookup_table.meta.authority.is_none() {
             msg!("Lookup table is frozen");
-            // [Core BPF]: TODO: Should be `ProgramError::Immutable`
-            // See https://github.com/solana-labs/solana/pull/35113
-            return Err(ProgramError::Custom(0));
+            return Err(ProgramError::Immutable);
         }
         if lookup_table.meta.authority != Some(*authority_info.key) {
             msg!("Incorrect lookup table authority");
-            // [Core BPF]: TODO: Should be `ProgramError::IncorrectAuthority`
-            // See https://github.com/solana-labs/solana/pull/35113
-            return Err(ProgramError::Custom(0));
+            return Err(ProgramError::IncorrectAuthority);
         }
         if lookup_table.meta.deactivation_slot != Slot::MAX {
             msg!("Deactivated tables cannot be extended");
@@ -341,15 +333,11 @@ fn process_deactivate_lookup_table(program_id: &Pubkey, accounts: &[AccountInfo]
 
         if lookup_table.meta.authority.is_none() {
             msg!("Lookup table is frozen");
-            // [Core BPF]: TODO: Should be `ProgramError::Immutable`
-            // See https://github.com/solana-labs/solana/pull/35113
-            return Err(ProgramError::Custom(0));
+            return Err(ProgramError::Immutable);
         }
         if lookup_table.meta.authority != Some(*authority_info.key) {
             msg!("Incorrect lookup table authority");
-            // [Core BPF]: TODO: Should be `ProgramError::IncorrectAuthority`
-            // See https://github.com/solana-labs/solana/pull/35113
-            return Err(ProgramError::Custom(0));
+            return Err(ProgramError::IncorrectAuthority);
         }
         if lookup_table.meta.deactivation_slot != Slot::MAX {
             msg!("Lookup table is already deactivated");
@@ -405,15 +393,11 @@ fn process_close_lookup_table(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
 
         if lookup_table.meta.authority.is_none() {
             msg!("Lookup table is frozen");
-            // [Core BPF]: TODO: Should be `ProgramError::Immutable`
-            // See https://github.com/solana-labs/solana/pull/35113
-            return Err(ProgramError::Custom(0));
+            return Err(ProgramError::Immutable);
         }
         if lookup_table.meta.authority != Some(*authority_info.key) {
             msg!("Incorrect lookup table authority");
-            // [Core BPF]: TODO: Should be `ProgramError::IncorrectAuthority`
-            // See https://github.com/solana-labs/solana/pull/35113
-            return Err(ProgramError::Custom(0));
+            return Err(ProgramError::IncorrectAuthority);
         }
 
         let clock = <Clock as Sysvar>::get()?;

--- a/program/tests/close_lookup_table_ix.rs
+++ b/program/tests/close_lookup_table_ix.rs
@@ -195,10 +195,7 @@ async fn test_close_immutable_lookup_table() {
         &mut context,
         ix,
         Some(&authority),
-        // [Core BPF]: TODO: Should be `ProgramError::Immutable`
-        // See https://github.com/solana-labs/solana/pull/35113
-        // InstructionError::Immutable,
-        InstructionError::Custom(0),
+        InstructionError::Immutable,
     )
     .await;
 }
@@ -223,10 +220,7 @@ async fn test_close_lookup_table_with_wrong_authority() {
         &mut context,
         ix,
         Some(&wrong_authority),
-        // [Core BPF]: TODO: Should be `ProgramError::Immutable`
-        // See https://github.com/solana-labs/solana/pull/35113
-        // InstructionError::IncorrectAuthority,
-        InstructionError::Custom(0),
+        InstructionError::IncorrectAuthority,
     )
     .await;
 }

--- a/program/tests/deactivate_lookup_table_ix.rs
+++ b/program/tests/deactivate_lookup_table_ix.rs
@@ -77,10 +77,7 @@ async fn test_deactivate_immutable_lookup_table() {
         &mut context,
         ix,
         Some(&authority),
-        // [Core BPF]: TODO: Should be `ProgramError::Immutable`
-        // See https://github.com/solana-labs/solana/pull/35113
-        // InstructionError::Immutable,
-        InstructionError::Custom(0),
+        InstructionError::Immutable,
     )
     .await;
 }
@@ -125,10 +122,7 @@ async fn test_deactivate_lookup_table_with_wrong_authority() {
         &mut context,
         ix,
         Some(&wrong_authority),
-        // [Core BPF]: TODO: Should be `ProgramError::Immutable`
-        // See https://github.com/solana-labs/solana/pull/35113
-        // InstructionError::IncorrectAuthority,
-        InstructionError::Custom(0),
+        InstructionError::IncorrectAuthority,
     )
     .await;
 }

--- a/program/tests/extend_lookup_table_ix.rs
+++ b/program/tests/extend_lookup_table_ix.rs
@@ -183,10 +183,7 @@ async fn test_extend_lookup_table_with_wrong_authority() {
         &mut context,
         ix,
         Some(&wrong_authority),
-        // [Core BPF]: TODO: Should be `ProgramError::Immutable`
-        // See https://github.com/solana-labs/solana/pull/35113
-        // InstructionError::IncorrectAuthority,
-        InstructionError::Custom(0),
+        InstructionError::IncorrectAuthority,
     )
     .await;
 }
@@ -269,10 +266,7 @@ async fn test_extend_immutable_lookup_table() {
         &mut context,
         ix,
         Some(&authority),
-        // [Core BPF]: TODO: Should be `ProgramError::Immutable`
-        // See https://github.com/solana-labs/solana/pull/35113
-        // InstructionError::Immutable,
-        InstructionError::Custom(0),
+        InstructionError::Immutable,
     )
     .await;
 }

--- a/program/tests/freeze_lookup_table_ix.rs
+++ b/program/tests/freeze_lookup_table_ix.rs
@@ -77,10 +77,7 @@ async fn test_freeze_immutable_lookup_table() {
         &mut context,
         ix,
         Some(&authority),
-        // [Core BPF]: TODO: Should be `ProgramError::Immutable`
-        // See https://github.com/solana-labs/solana/pull/35113
-        // InstructionError::Immutable,
-        InstructionError::Custom(0),
+        InstructionError::Immutable,
     )
     .await;
 }
@@ -125,10 +122,7 @@ async fn test_freeze_lookup_table_with_wrong_authority() {
         &mut context,
         ix,
         Some(&wrong_authority),
-        // [Core BPF]: TODO: Should be `ProgramError::Immutable`
-        // See https://github.com/solana-labs/solana/pull/35113
-        // InstructionError::IncorrectAuthority,
-        InstructionError::Custom(0),
+        InstructionError::IncorrectAuthority,
     )
     .await;
 }


### PR DESCRIPTION
#### Problem
In the first BPF implementation of the program, we had to temporarily skip a few
error codes, since they weren't available in the `ProgramError` enum yet.

Now that 2.0 has been released, those errors are available.

#### Summary of Changes
Add the missing errors!