### PR TITLE
Use proper program id in program tests

### DIFF
--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -10,7 +10,4 @@ pub mod instruction;
 pub mod processor;
 pub mod state;
 
-// [Core BPF]: TODO: Program-test will not overwrite existing built-ins.
-// See https://github.com/solana-labs/solana/pull/35233
-// solana_program::declare_id!("AddressLookupTab1e1111111111111111111111111");
-solana_program::declare_id!("AaoNx79M6YE3DcXfrRN4nmBcQvQPqdpowi6uEESuJdnm");
+solana_program::declare_id!("AddressLookupTab1e1111111111111111111111111");

--- a/program/tests/common.rs
+++ b/program/tests/common.rs
@@ -16,11 +16,9 @@ use {
 
 pub async fn setup_test_context() -> ProgramTestContext {
     let mut program_test = ProgramTest::default();
-    program_test.prefer_bpf(true);
-    program_test.add_program(
+    program_test.add_upgradeable_program_to_genesis(
         "solana_address_lookup_table_program",
-        solana_address_lookup_table_program::id(),
-        processor!(solana_address_lookup_table_program::processor::process),
+        &solana_address_lookup_table_program::id(),
     );
     program_test.start_with_context().await
 }


### PR DESCRIPTION
#### Problem
In the first BPF implementation of the program, we had to temporarily use an
arbitrary program ID in order to successfully test the program as a BPF
program.

Now that 2.0 is released, we can use `add_upgradeable_program_to_genesis`
to add a Core BPF program to the Bank and prevent it from being overwritten
by its original builtin counterpart.

#### Summary of Changes
Update the tests to use this new method, and the proper ID for the program!