### PR TITLE
Update to use `SlotHashes` for cooldown

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -19,7 +19,7 @@ use {
         rent::Rent,
         slot_hashes::MAX_ENTRIES,
         system_instruction,
-        sysvar::Sysvar,
+        sysvar::{slot_hashes::SlotHashesSysvar, Sysvar},
     },
 };
 
@@ -31,43 +31,18 @@ enum LookupTableStatus {
     Deactivated,
 }
 
-// [Core BPF]: Newly-implemented logic for calculating slot position relative
-// to the current slot on the `Clock`.
-// In the original implementation, `slot_hashes.position()` can return
-// `Some(position)` where `position` is in the range `0..511`.
-// Position `0` means `MAX_ENTRIES - 0 = 512` blocks remaining.
-// Position `511` means `MAX_ENTRIES - 511 = 1` block remaining.
-// To account for that range, considering the current slot would not be present
-// in the `SlotHashes` sysvar, we need to first subtract `1` from the current
-// slot, and then subtract the target slot from the result.
-fn calculate_slot_position(target_slot: &Slot, current_slot: &Slot) -> Option<usize> {
-    let position = current_slot.saturating_sub(*target_slot);
-
-    if position >= (MAX_ENTRIES as u64) {
-        return None;
-    }
-    Some(position as usize)
-}
-
-// [Core BPF]: This function has been modified from its legacy built-in
-// counterpart to no longer use the `SlotHashes` sysvar, since it is not
-// available for BPF programs. Instead, it uses the `current_slot`
-// parameter to calculate the table's status.
-// This will no longer consider the case where a slot has been skipped
-// and no block was produced.
-// If it's imperative to ensure we are only considering slots where blocks
-// were created, then we'll need to revisit this function, and possibly
-// provide the `SlotHashes` account so we can reliably check slot hashes.
-/// Return the current status of the lookup table
-fn get_lookup_table_status(deactivation_slot: Slot, current_slot: Slot) -> LookupTableStatus {
+// Return the current status of the lookup table
+fn get_lookup_table_status(
+    deactivation_slot: Slot,
+    current_slot: Slot,
+) -> Result<LookupTableStatus, ProgramError> {
     if deactivation_slot == Slot::MAX {
-        LookupTableStatus::Activated
+        Ok(LookupTableStatus::Activated)
     } else if deactivation_slot == current_slot {
-        LookupTableStatus::Deactivating {
-            remaining_blocks: MAX_ENTRIES,
-        }
-    } else if let Some(slot_position) = calculate_slot_position(&deactivation_slot, &current_slot) {
-        // [Core BPF]: TODO: `Clock` instead of `SlotHashes`.
+        Ok(LookupTableStatus::Deactivating {
+            remaining_blocks: MAX_ENTRIES.saturating_add(1),
+        })
+    } else if let Some(slot_position) = SlotHashesSysvar::position(&deactivation_slot)? {
         // Deactivation requires a cool-down period to give in-flight transactions
         // enough time to land and to remove indeterminism caused by transactions
         // loading addresses in the same slot when a table is closed. The
@@ -77,11 +52,11 @@ fn get_lookup_table_status(deactivation_slot: Slot, current_slot: Slot) -> Looku
         // By using the slot hash to enforce the cool-down, there is a side effect
         // of not allowing lookup tables to be recreated at the same derived address
         // because tables must be created at an address derived from a recent slot.
-        LookupTableStatus::Deactivating {
+        Ok(LookupTableStatus::Deactivating {
             remaining_blocks: MAX_ENTRIES.saturating_sub(slot_position),
-        }
+        })
     } else {
-        LookupTableStatus::Deactivated
+        Ok(LookupTableStatus::Deactivated)
     }
 }
 
@@ -122,18 +97,8 @@ fn process_create_lookup_table(
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    // [Core BPF]: Since the `SlotHashes` sysvar is not available to BPF
-    // programs, checking if a slot is a valid recent slot must be done
-    // differently.
-    // The `SlotHashes` sysvar stores up to `512` recent slots (`MAX_ENTRIES`).
-    // We can instead use the `Clock` sysvar and do this math manually.
-    //
-    // Note this will no longer consider skipped slots wherein a block was not
-    // produced.
     let derivation_slot = {
-        let clock = <Clock as Sysvar>::get()?;
-        let oldest_possible_slot = clock.slot.saturating_sub(MAX_ENTRIES as u64);
-        if untrusted_recent_slot >= oldest_possible_slot && untrusted_recent_slot < clock.slot {
+        if SlotHashesSysvar::get(&untrusted_recent_slot)?.is_some() {
             Ok(untrusted_recent_slot)
         } else {
             msg!("{} is not a recent slot", untrusted_recent_slot);
@@ -463,14 +428,7 @@ fn process_close_lookup_table(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
 
         let clock = <Clock as Sysvar>::get()?;
 
-        // [Core BPF]: Again, since the `SlotHashes` sysvar is not available to
-        // BPF programs, we can't use the `SlotHashes` sysvar to check the
-        // status of a lookup table.
-        // Again we instead use the `Clock` sysvar here.
-        // This will no longer consider skipped slots wherein a block was not
-        // produced.
-        // See `state::LookupTableMeta::status` for more details.
-        match get_lookup_table_status(lookup_table.meta.deactivation_slot, clock.slot) {
+        match get_lookup_table_status(lookup_table.meta.deactivation_slot, clock.slot)? {
             LookupTableStatus::Activated => {
                 msg!("Lookup table is not deactivated");
                 Err(ProgramError::InvalidArgument)

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -16,7 +16,6 @@ pub const LOOKUP_TABLE_META_SIZE: usize = 56;
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct LookupTableMeta {
-    // [Core BPF]: TODO: `Clock` instead of `SlotHashes`.
     /// Lookup tables cannot be closed until the deactivation slot is
     /// no longer "recent" (not accessible in the `SlotHashes` sysvar).
     pub deactivation_slot: Slot,

--- a/program/tests/close_lookup_table_ix.rs
+++ b/program/tests/close_lookup_table_ix.rs
@@ -22,13 +22,15 @@ mod common;
 async fn test_close_lookup_table() {
     // Succesfully close a deactived lookup table.
     let mut context = setup_test_context().await;
+
+    context.warp_to_slot(2).unwrap();
     overwrite_slot_hashes_with_slots(&context, &[]);
 
     let lookup_table_address = Pubkey::new_unique();
     let authority_keypair = Keypair::new();
     let initialized_table = {
         let mut table = new_address_lookup_table(Some(authority_keypair.pubkey()), 0);
-        table.meta.deactivation_slot = 0;
+        table.meta.deactivation_slot = 1;
         table
     };
     add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;

--- a/program/tests/common.rs
+++ b/program/tests/common.rs
@@ -6,9 +6,12 @@ use {
     solana_program_test::*,
     solana_sdk::{
         account::AccountSharedData,
+        clock::Slot,
+        hash::Hash,
         instruction::{Instruction, InstructionError},
         pubkey::Pubkey,
         signature::{Keypair, Signer},
+        slot_hashes::SlotHashes,
         transaction::{Transaction, TransactionError},
     },
     std::borrow::Cow,
@@ -88,4 +91,12 @@ pub async fn add_lookup_table_account(
     context.set_account(&account_address, &account);
 
     account
+}
+
+pub fn overwrite_slot_hashes_with_slots(context: &ProgramTestContext, slots: &[Slot]) {
+    let mut slot_hashes = SlotHashes::default();
+    for slot in slots {
+        slot_hashes.add(*slot, Hash::new_unique());
+    }
+    context.set_sysvar(&slot_hashes);
 }

--- a/program/tests/create_lookup_table_ix.rs
+++ b/program/tests/create_lookup_table_ix.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "test-sbf")]
 
 use {
-    common::{assert_ix_error, setup_test_context},
+    common::{assert_ix_error, overwrite_slot_hashes_with_slots, setup_test_context},
     solana_address_lookup_table_program::{
         instruction::create_lookup_table,
         state::{AddressLookupTable, LOOKUP_TABLE_META_SIZE},
@@ -25,8 +25,7 @@ async fn test_create_lookup_table_idempotent() {
     let mut context = setup_test_context().await;
 
     let test_recent_slot = 123;
-    // [Core BPF]: Warping to slot instead of overwriting `SlotHashes`.
-    context.warp_to_slot(test_recent_slot + 1).unwrap();
+    overwrite_slot_hashes_with_slots(&context, &[122, test_recent_slot, 124]);
 
     let client = &mut context.banks_client;
     let payer = &context.payer;
@@ -95,8 +94,7 @@ async fn test_create_lookup_table_use_payer_as_authority() {
     let mut context = setup_test_context().await;
 
     let test_recent_slot = 123;
-    // [Core BPF]: Warping to slot instead of overwriting `SlotHashes`.
-    context.warp_to_slot(test_recent_slot + 1).unwrap();
+    overwrite_slot_hashes_with_slots(&context, &[test_recent_slot]);
 
     let client = &mut context.banks_client;
     let payer = &context.payer;
@@ -137,8 +135,7 @@ async fn test_create_lookup_table_pda_mismatch() {
     let mut context = setup_test_context().await;
 
     let test_recent_slot = 123;
-    // [Core BPF]: Warping to slot instead of overwriting `SlotHashes`.
-    context.warp_to_slot(test_recent_slot + 1).unwrap();
+    overwrite_slot_hashes_with_slots(&context, &[test_recent_slot]);
 
     let payer = &context.payer;
     let authority_address = Pubkey::new_unique();


### PR DESCRIPTION
#### Problem
The original builtin version of Address Lookup Table used the `SlotHashes` sysvar
to determine a lookup table's cooldown period, as well as validating its slot as a
recent slot.

In the BPF reimplementation, since `SlotHashes` wasn't available to BPF programs,
we modified this behavior by instead using `Clock` and calculating the recent slot
based on the lookup table's slot and the current slot in the clock. This resulted in
cooldown periods counting _only_ the difference in slots from the clock, regardless
of whether or not any particular slot was one with a valid block produced.

Now that `SlotHashes` is available to BPF programs through the new `sol_get_sysvar`
syscall, we can update the BPF version of the program to behave exactly the same as
the original.

#### Summary of Changes
First drop some public state methods that were available in the original SDK. In the
future, we may need to add these to AccountsDB, and can do so when that time
comes. In the meantime, they won't be available through the lookup table program or
its clients.

Then port the "status" check on a look table into the processor itself, since once it's
using `SlotHashesSysvar` it will only work in a BPF context.

Finally update the program to use `SlotHashesSysvar`, driving the new `sol_get_sysvar`
syscall to use `SlotHashes` like the original program.