### PR TITLE
Rewrite tests with Mollusk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,9 +1700,9 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm"
-version = "0.0.3"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38072bf31f98d09392977ccea75bb847b206bc7c6e010ae04a09aa0825dbed00"
+checksum = "5e00a3c8619ad0f23fc255d05892f4b100622a0d2a1fda2798474c99a87bbf1e"
 dependencies = [
  "bincode",
  "solana-bpf-loader-program",
@@ -1711,6 +1711,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-sdk",
  "solana-system-program",
+ "thiserror",
 ]
 
 [[package]]
@@ -3121,18 +3122,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,6 @@
 version = 3
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,42 +16,6 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
-name = "aead"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
-dependencies = [
- "crypto-common",
- "generic-array",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "aes-gcm-siv"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "polyval",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "ahash"
@@ -81,7 +35,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -180,7 +133,7 @@ dependencies = [
  "anchor-syn",
  "anyhow",
  "bs58 0.5.1",
- "heck 0.3.3",
+ "heck",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -255,7 +208,7 @@ checksum = "31cf97b4e6f7d6144a05e435660fcf757dbc3446d38d0e2b851d11ed13625bba"
 dependencies = [
  "anchor-lang-idl-spec",
  "anyhow",
- "heck 0.3.3",
+ "heck",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -279,7 +232,7 @@ checksum = "f99daacb53b55cfd37ce14d6c9905929721137fd4c67bbab44a19802aecb622f"
 dependencies = [
  "anyhow",
  "bs58 0.5.1",
- "heck 0.3.3",
+ "heck",
  "proc-macro2",
  "quote",
  "serde",
@@ -305,33 +258,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
-
-[[package]]
-name = "aquamarine"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da02abba9f9063d786eab1509833ebb2fac0f966862ca59439c76b9c566760"
-dependencies = [
- "include_dir",
- "itertools 0.10.5",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "ark-bn254"
@@ -469,62 +399,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
-name = "asn1-rs"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
-dependencies = [
- "asn1-rs-derive",
- "asn1-rs-impl",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror",
- "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure",
-]
-
-[[package]]
-name = "asn1-rs-impl"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "assert_matches"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,32 +413,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-mutex"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
-name = "async-trait"
-version = "0.1.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.68",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
  "libc",
  "winapi",
 ]
@@ -595,12 +449,6 @@ name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -667,7 +515,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -679,12 +526,6 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "borsh"
@@ -713,7 +554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
 dependencies = [
  "borsh-derive 1.5.1",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
 ]
 
 [[package]]
@@ -885,37 +726,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
-name = "caps"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190baaad529bcfbde9e1a19022c42781bdb6ff9de25721abdb8fd98c0807730b"
-dependencies = [
- "libc",
- "thiserror",
-]
-
-[[package]]
 name = "cc"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,12 +743,6 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -951,70 +755,9 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-targets 0.52.5",
-]
-
-[[package]]
-name = "chrono-humanize"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799627e6b4d27827a814e837b9d8a504832086081806d45b1afa34dc982b023b"
-dependencies = [
- "chrono",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
-]
-
-[[package]]
-name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "atty",
- "bitflags 1.3.2",
- "clap_lex",
- "indexmap 1.9.3",
- "once_cell",
- "strsim 0.10.0",
- "termcolor",
- "textwrap 0.16.1",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -1028,28 +771,6 @@ dependencies = [
  "either",
  "memchr",
  "unreachable",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "console"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "unicode-width",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1159,7 +880,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1171,15 +891,6 @@ checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array",
  "subtle",
-]
-
-[[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher",
 ]
 
 [[package]]
@@ -1216,7 +927,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.68",
 ]
 
@@ -1229,40 +940,6 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.68",
-]
-
-[[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
- "rayon",
-]
-
-[[package]]
-name = "data-encoding"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
-
-[[package]]
-name = "der-parser"
-version = "8.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
-dependencies = [
- "asn1-rs",
- "displaydoc",
- "nom",
- "num-bigint 0.4.5",
- "num-traits",
- "rusticata-macros",
 ]
 
 [[package]]
@@ -1293,24 +970,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dialoguer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
-dependencies = [
- "console",
- "shell-words",
- "tempfile",
- "zeroize",
-]
-
-[[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,55 +988,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "dir-diff"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ad16bf5f84253b50d6557681c58c3ab67c47c77d39fed9aeb56e947290bd10"
-dependencies = [
- "walkdir",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.68",
-]
-
-[[package]]
-name = "dlopen2"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b4f5f101177ff01b8ec4ecc81eead416a8aa42819a2869311b3420fa114ffa"
-dependencies = [
- "dlopen2_derive",
- "libc",
- "once_cell",
- "winapi",
-]
-
-[[package]]
-name = "dlopen2_derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cbae11b3de8fce2a456e8ea3dada226b35fe791f0dc1d360c0941f0bb681f3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.68",
-]
-
-[[package]]
-name = "downcast"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "eager"
@@ -1421,28 +1031,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "educe"
-version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f"
-dependencies = [
- "enum-ordinalize",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "either"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
-
-[[package]]
-name = "encode_unicode"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -1474,19 +1066,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-ordinalize"
-version = "3.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee"
-dependencies = [
- "num-bigint 0.4.5",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 2.0.68",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,50 +1085,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "errno"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "fastrand"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
-
-[[package]]
 name = "feature-probe"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
-
-[[package]]
-name = "filetime"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall 0.4.1",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1559,15 +1098,6 @@ checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
-]
-
-[[package]]
-name = "float-cmp"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -1586,34 +1116,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "fragile"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
-
-[[package]]
-name = "futures"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -1623,32 +1131,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
-name = "futures-executor"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.68",
-]
 
 [[package]]
 name = "futures-sink"
@@ -1668,11 +1154,8 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
- "futures-macro",
- "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -1759,7 +1242,7 @@ dependencies = [
  "indexmap 2.2.6",
  "slab",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
  "tracing",
 ]
 
@@ -1812,12 +1295,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1827,22 +1304,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "histogram"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
 
 [[package]]
 name = "hmac"
@@ -1872,15 +1337,6 @@ dependencies = [
  "digest 0.9.0",
  "generic-array",
  "hmac 0.8.1",
-]
-
-[[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2017,31 +1473,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "index_list"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70891286cb8e844fdfcf1178b47569699f9e20b5ecc4b45a6240a64771444638"
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2061,37 +1492,6 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
  "serde",
-]
-
-[[package]]
-name = "indicatif"
-version = "0.17.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
-dependencies = [
- "console",
- "instant",
- "number_prefix",
- "portable-atomic",
- "unicode-width",
-]
-
-[[package]]
-name = "inout"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -2140,21 +1540,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
-]
-
-[[package]]
-name = "jsonrpc-core"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
-dependencies = [
- "futures",
- "futures-executor",
- "futures-util",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
 ]
 
 [[package]]
@@ -2248,12 +1633,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
-
-[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2268,26 +1647,6 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
-
-[[package]]
-name = "lz4"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6eab492fe7f8651add23237ea56dbf11b3c4ff762ab83d40a47f11433421f91"
-dependencies = [
- "libc",
- "lz4-sys",
-]
-
-[[package]]
-name = "lz4-sys"
-version = "1.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9764018d143cc854c9f17f0b907de70f14393b1f502da6375dce70f00514eb3"
-dependencies = [
- "cc",
- "libc",
-]
 
 [[package]]
 name = "memchr"
@@ -2314,38 +1673,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "merlin"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
-dependencies = [
- "byteorder",
- "keccak",
- "rand_core 0.6.4",
- "zeroize",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2368,87 +1699,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "mockall"
-version = "0.11.4"
+name = "mollusk-svm"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
+checksum = "38072bf31f98d09392977ccea75bb847b206bc7c6e010ae04a09aa0825dbed00"
 dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "lazy_static",
- "mockall_derive",
- "predicates",
- "predicates-tree",
+ "bincode",
+ "solana-bpf-loader-program",
+ "solana-compute-budget",
+ "solana-logger",
+ "solana-program-runtime",
+ "solana-sdk",
+ "solana-system-program",
 ]
-
-[[package]]
-name = "mockall_derive"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "modular-bitfield"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
-dependencies = [
- "modular-bitfield-impl",
- "static_assertions",
-]
-
-[[package]]
-name = "modular-bitfield-impl"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "nix"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "cfg_aliases 0.1.1",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num"
@@ -2565,16 +1828,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
-]
-
-[[package]]
 name = "num_enum"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2596,27 +1849,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "object"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "oid-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
-dependencies = [
- "asn1-rs",
 ]
 
 [[package]]
@@ -2630,37 +1868,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "opentelemetry"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "js-sys",
- "lazy_static",
- "percent-encoding",
- "pin-project",
- "rand 0.8.5",
- "thiserror",
-]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "parking_lot"
@@ -2680,7 +1887,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.2",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.52.5",
 ]
@@ -2710,15 +1917,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
-dependencies = [
- "base64 0.13.1",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2734,36 +1932,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.2.6",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.68",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2776,34 +1944,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
 name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
-name = "polyval"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
-]
-
-[[package]]
-name = "portable-atomic"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "powerfmt"
@@ -2816,46 +1960,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "predicates"
-version = "2.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
-dependencies = [
- "difflib",
- "float-cmp",
- "itertools 0.10.5",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
-dependencies = [
- "predicates-core",
- "termtree",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "proc-macro-crate"
@@ -2884,7 +1988,6 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
  "version_check",
 ]
 
@@ -2909,125 +2012,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
-dependencies = [
- "bytes",
- "heck 0.4.1",
- "itertools 0.10.5",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn 1.0.109",
- "tempfile",
- "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
-dependencies = [
- "prost",
-]
-
-[[package]]
 name = "qstring"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "qualifier_attr"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2e25ee72f5b24d773cae88422baddefff7714f97aab68d96fe2b6fc4a28fb2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.68",
-]
-
-[[package]]
-name = "quinn"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc2c5017e4b43d5995dcea317bc46c1e09404c0a9664d2908f7f02dfe943d75"
-dependencies = [
- "bytes",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "141bf7dfde2fbc246bfd3fe12f2455aa24b0fbd9af535d8c86c7bd1381ff2b1a"
-dependencies = [
- "bytes",
- "rand 0.8.5",
- "ring 0.16.20",
- "rustc-hash",
- "rustls",
- "rustls-native-certs",
- "slab",
- "thiserror",
- "tinyvec",
- "tracing",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "055b4e778e8feb9f93c4e439f71dc2156ef13360b432b799e179a8c4cdf0b1d7"
-dependencies = [
- "bytes",
- "libc",
- "socket2",
- "tracing",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3141,15 +2131,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
@@ -3207,7 +2188,6 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -3220,44 +2200,14 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-rustls",
- "tokio-util 0.7.11",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.25.4",
+ "webpki-roots",
  "winreg",
-]
-
-[[package]]
-name = "reqwest-middleware"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a735987236a8e238bf0296c7e351b999c188ccc11477f311b82b55c93984216"
-dependencies = [
- "anyhow",
- "async-trait",
- "http",
- "reqwest",
- "serde",
- "task-local-extensions",
- "thiserror",
-]
-
-[[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
 ]
 
 [[package]]
@@ -3270,30 +2220,9 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin 0.9.8",
- "untrusted 0.9.0",
+ "spin",
+ "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rpassword"
-version = "7.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
-dependencies = [
- "libc",
- "rtoolbox",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rtoolbox"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3318,49 +2247,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusticata-macros"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
-dependencies = [
- "nom",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
-dependencies = [
- "bitflags 2.6.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "rustls"
 version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.8",
+ "ring",
  "rustls-webpki",
  "sct",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -3378,8 +2273,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3393,24 +2288,6 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
-dependencies = [
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "scopeguard"
@@ -3444,31 +2321,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
-dependencies = [
- "bitflags 2.6.0",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3476,15 +2330,6 @@ name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
-
-[[package]]
-name = "seqlock"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c67b6f14ecc5b86c66fa63d76b5092352678545a8a3cdae80aef5128371910"
-dependencies = [
- "parking_lot",
-]
 
 [[package]]
 name = "serde"
@@ -3591,17 +2436,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.7",
-]
-
-[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3627,48 +2461,12 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha3"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
  "keccak",
-]
-
-[[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
-name = "shell-words"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -3719,76 +2517,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-account-decoder"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ad8e8ea9c15fef1ee50b65beb61c5a298d97600d63721c834658a5e7fb6564"
-dependencies = [
- "Inflector",
- "base64 0.22.1",
- "bincode",
- "bs58 0.5.1",
- "bv",
- "lazy_static",
- "serde",
- "serde_derive",
- "serde_json",
- "solana-config-program",
- "solana-sdk",
- "spl-token",
- "spl-token-2022",
- "spl-token-group-interface",
- "spl-token-metadata-interface",
- "thiserror",
- "zstd",
-]
-
-[[package]]
-name = "solana-accounts-db"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b00649af033269e2006c784e72f07d2fc40cd8dd9e49fa86f92c588cd5f1580"
-dependencies = [
- "bincode",
- "blake3",
- "bv",
- "bytemuck",
- "bytemuck_derive",
- "bzip2",
- "crossbeam-channel",
- "dashmap",
- "index_list",
- "indexmap 2.2.6",
- "itertools 0.12.1",
- "lazy_static",
- "log",
- "lz4",
- "memmap2",
- "modular-bitfield",
- "num_cpus",
- "num_enum",
- "rand 0.8.5",
- "rayon",
- "rustc_version",
- "seqlock",
- "serde",
- "serde_derive",
- "smallvec",
- "solana-bucket-map",
- "solana-inline-spl",
- "solana-measure",
- "solana-metrics",
- "solana-nohash-hasher",
- "solana-rayon-threadlimit",
- "solana-sdk",
- "solana-svm",
- "static_assertions",
- "tar",
- "tempfile",
- "thiserror",
-]
-
-[[package]]
 name = "solana-address-lookup-table-client"
 version = "0.1.0"
 dependencies = [
@@ -3809,82 +2537,15 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "bytemuck",
+ "mollusk-svm",
  "rustc_version",
  "serde",
  "solana-frozen-abi 2.0.1",
  "solana-frozen-abi-macro 2.0.1",
  "solana-program 2.0.1",
- "solana-program-test",
  "solana-sdk",
- "spl-program-error 0.5.0",
+ "spl-program-error",
  "test-case",
-]
-
-[[package]]
-name = "solana-address-lookup-table-program"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc56805c3d5e76d988ef2fd25d1138d2dbdffceef655c0e9e0bfbc32a53a9f1"
-dependencies = [
- "bincode",
- "bytemuck",
- "log",
- "num-derive 0.4.2",
- "num-traits",
- "rustc_version",
- "solana-program 2.0.1",
- "solana-program-runtime",
- "solana-sdk",
- "thiserror",
-]
-
-[[package]]
-name = "solana-banks-client"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e84e1dff8344acfa3dd98d59b0b256166c160ee816d7e9be90ba402870c74e3"
-dependencies = [
- "borsh 1.5.1",
- "futures",
- "solana-banks-interface",
- "solana-program 2.0.1",
- "solana-sdk",
- "tarpc",
- "thiserror",
- "tokio",
- "tokio-serde",
-]
-
-[[package]]
-name = "solana-banks-interface"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63a46a278e7424b839876eb8b46f8558a2a9c0b0db167b55383fac197803a960"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk",
- "tarpc",
-]
-
-[[package]]
-name = "solana-banks-server"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb49aeaf0aa57df22cebc6803f584d1f89279f460cce94eefc03eef462e2189"
-dependencies = [
- "bincode",
- "crossbeam-channel",
- "futures",
- "solana-banks-interface",
- "solana-client",
- "solana-runtime",
- "solana-sdk",
- "solana-send-transaction-service",
- "solana-svm",
- "tarpc",
- "tokio",
- "tokio-serde",
 ]
 
 [[package]]
@@ -3910,75 +2571,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-bucket-map"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c7c4dd872c9797eff7d34587af4369012c9bd521c7e6ad68ac8e97e4c6343b"
-dependencies = [
- "bv",
- "bytemuck",
- "bytemuck_derive",
- "log",
- "memmap2",
- "modular-bitfield",
- "num_enum",
- "rand 0.8.5",
- "solana-measure",
- "solana-sdk",
- "tempfile",
-]
-
-[[package]]
-name = "solana-clap-utils"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e6f9acdd27a5ae888f7f3e1820f5b50bea4d74d60eb75d96e5f82fea58c8cc"
-dependencies = [
- "chrono",
- "clap 2.34.0",
- "rpassword",
- "solana-remote-wallet",
- "solana-sdk",
- "thiserror",
- "tiny-bip39",
- "uriparse",
- "url",
-]
-
-[[package]]
-name = "solana-client"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4d5c1fab1945962c380e1be11a6081e68ccabafe3bafead2c19393a132887ec"
-dependencies = [
- "async-trait",
- "bincode",
- "dashmap",
- "futures",
- "futures-util",
- "indexmap 2.2.6",
- "indicatif",
- "log",
- "quinn",
- "rayon",
- "solana-connection-cache",
- "solana-measure",
- "solana-metrics",
- "solana-pubsub-client",
- "solana-quic-client",
- "solana-rpc-client",
- "solana-rpc-client-api",
- "solana-rpc-client-nonce-utils",
- "solana-sdk",
- "solana-streamer",
- "solana-thin-client",
- "solana-tpu-client",
- "solana-udp-client",
- "thiserror",
- "tokio",
-]
-
-[[package]]
 name = "solana-compute-budget"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3986,74 +2578,6 @@ checksum = "d9c82354d659776e22807b3dfa6a1eb23dbf9f9a1a72b9a99ecb6a56f9a0e832"
 dependencies = [
  "rustc_version",
  "solana-sdk",
-]
-
-[[package]]
-name = "solana-compute-budget-program"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41155db502f7ca5e981cc550f491bbe9a4cf85c717f7e3f569d2f57593fd7a8a"
-dependencies = [
- "solana-program-runtime",
- "solana-sdk",
-]
-
-[[package]]
-name = "solana-config-program"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b94efabb36a5f380632c6c7a3cd44b515c6ae4637464bb0f40d69581c1365d"
-dependencies = [
- "bincode",
- "chrono",
- "serde",
- "serde_derive",
- "solana-program-runtime",
- "solana-sdk",
-]
-
-[[package]]
-name = "solana-connection-cache"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c020b32972894093ca5dacb8f67e649a6148cd7d7bf4c5ff61c5f4745cfb6b0a"
-dependencies = [
- "async-trait",
- "bincode",
- "crossbeam-channel",
- "futures-util",
- "indexmap 2.2.6",
- "log",
- "rand 0.8.5",
- "rayon",
- "solana-measure",
- "solana-metrics",
- "solana-sdk",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "solana-cost-model"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db46334f743b8da3539d47657f951fb8a04922c3aef46d6866066e14efe7d37c"
-dependencies = [
- "ahash 0.8.11",
- "lazy_static",
- "log",
- "rustc_version",
- "solana-address-lookup-table-program 2.0.1",
- "solana-bpf-loader-program",
- "solana-compute-budget",
- "solana-compute-budget-program",
- "solana-config-program",
- "solana-loader-v4-program",
- "solana-metrics",
- "solana-sdk",
- "solana-stake-program",
- "solana-system-program",
- "solana-vote-program",
 ]
 
 [[package]]
@@ -4139,32 +2663,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-inline-spl"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5f6170e189fc780aea44b4dfca1fe63f2a0578d376afcb779bdd0514a6df385"
-dependencies = [
- "bytemuck",
- "rustc_version",
- "solana-sdk",
-]
-
-[[package]]
-name = "solana-loader-v4-program"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4287af733bf7ddd19a1596080d5fd1962a8ffd52389e38edb2f458c860323c60"
-dependencies = [
- "log",
- "solana-compute-budget",
- "solana-measure",
- "solana-program-runtime",
- "solana-sdk",
- "solana-type-overrides",
- "solana_rbpf",
-]
-
-[[package]]
 name = "solana-logger"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4198,62 +2696,6 @@ dependencies = [
  "reqwest",
  "solana-sdk",
  "thiserror",
-]
-
-[[package]]
-name = "solana-net-utils"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e5caadd2e9be6ed83b2f219d731e4407dc1a6368103ac1bfc709d63de32a18"
-dependencies = [
- "bincode",
- "clap 3.2.25",
- "crossbeam-channel",
- "log",
- "nix",
- "rand 0.8.5",
- "serde",
- "serde_derive",
- "socket2",
- "solana-logger",
- "solana-sdk",
- "solana-version",
- "static_assertions",
- "tokio",
- "url",
-]
-
-[[package]]
-name = "solana-nohash-hasher"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8a731ed60e89177c8a7ab05fe0f1511cedd3e70e773f288f9de33a9cfdc21e"
-
-[[package]]
-name = "solana-perf"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac09983091108c30e55d672e8a0690a1f2a952131aafa2e0e503fb4eb97b0f91"
-dependencies = [
- "ahash 0.8.11",
- "bincode",
- "bv",
- "caps",
- "curve25519-dalek",
- "dlopen2",
- "fnv",
- "lazy_static",
- "libc",
- "log",
- "nix",
- "rand 0.8.5",
- "rayon",
- "rustc_version",
- "serde",
- "solana-metrics",
- "solana-rayon-threadlimit",
- "solana-sdk",
- "solana-vote-program",
 ]
 
 [[package]]
@@ -4312,7 +2754,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.8",
- "sha3 0.10.8",
+ "sha3",
  "solana-frozen-abi 1.18.21",
  "solana-frozen-abi-macro 1.18.21",
  "solana-sdk-macro 1.18.21",
@@ -4362,7 +2804,7 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "sha2 0.10.8",
- "sha3 0.10.8",
+ "sha3",
  "solana-sdk-macro 2.0.1",
  "thiserror",
  "wasm-bindgen",
@@ -4395,262 +2837,6 @@ dependencies = [
  "solana-vote",
  "solana_rbpf",
  "thiserror",
-]
-
-[[package]]
-name = "solana-program-test"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d7bcef316c2d497315d08fada47765a12541760f054b51308dd7b811489d2af"
-dependencies = [
- "assert_matches",
- "async-trait",
- "base64 0.22.1",
- "bincode",
- "chrono-humanize",
- "crossbeam-channel",
- "log",
- "serde",
- "solana-accounts-db",
- "solana-banks-client",
- "solana-banks-interface",
- "solana-banks-server",
- "solana-bpf-loader-program",
- "solana-compute-budget",
- "solana-inline-spl",
- "solana-logger",
- "solana-program-runtime",
- "solana-runtime",
- "solana-sdk",
- "solana-svm",
- "solana-vote-program",
- "solana_rbpf",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "solana-pubsub-client"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f572dae6680b15f42ee53505c0384a9f5be06424e6a62364449efb6f23cbde0b"
-dependencies = [
- "crossbeam-channel",
- "futures-util",
- "log",
- "reqwest",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "solana-account-decoder",
- "solana-rpc-client-api",
- "solana-sdk",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tokio-tungstenite",
- "tungstenite",
- "url",
-]
-
-[[package]]
-name = "solana-quic-client"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b773efed5939b2c7c2b9490f529f5dc3f5f940dbac5b2f514050fe871333ce1"
-dependencies = [
- "async-mutex",
- "async-trait",
- "futures",
- "itertools 0.12.1",
- "lazy_static",
- "log",
- "quinn",
- "quinn-proto",
- "rustls",
- "solana-connection-cache",
- "solana-measure",
- "solana-metrics",
- "solana-net-utils",
- "solana-rpc-client-api",
- "solana-sdk",
- "solana-streamer",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "solana-rayon-threadlimit"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccedf79026e11772482536696603a67eda3d07b497e1ec9eed6692e466a6bf37"
-dependencies = [
- "lazy_static",
- "num_cpus",
-]
-
-[[package]]
-name = "solana-remote-wallet"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7c9dd69628898c5235810b2cdddb26f8c5a3176f6567971a72aac9538f2d32"
-dependencies = [
- "console",
- "dialoguer",
- "log",
- "num-derive 0.4.2",
- "num-traits",
- "parking_lot",
- "qstring",
- "semver",
- "solana-sdk",
- "thiserror",
- "uriparse",
-]
-
-[[package]]
-name = "solana-rpc-client"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5845db742a0bf27662c592750f8029fa25f0d1c2700798e9bdf8a664744d6df4"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bincode",
- "bs58 0.5.1",
- "indicatif",
- "log",
- "reqwest",
- "reqwest-middleware",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "solana-account-decoder",
- "solana-rpc-client-api",
- "solana-sdk",
- "solana-transaction-status",
- "solana-version",
- "solana-vote-program",
- "tokio",
-]
-
-[[package]]
-name = "solana-rpc-client-api"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402af4866a7f9b96ffe45792932d43585504b7a92d0b75ae23a9a14fd1b1820f"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "bs58 0.5.1",
- "jsonrpc-core",
- "reqwest",
- "reqwest-middleware",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "solana-account-decoder",
- "solana-inline-spl",
- "solana-sdk",
- "solana-transaction-status",
- "solana-version",
- "thiserror",
-]
-
-[[package]]
-name = "solana-rpc-client-nonce-utils"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a1bb67541534c31b043e4fe5bfd3f4aaa04dca48e1c1e06b24c3e34f64f47"
-dependencies = [
- "clap 2.34.0",
- "solana-clap-utils",
- "solana-rpc-client",
- "solana-sdk",
- "thiserror",
-]
-
-[[package]]
-name = "solana-runtime"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e2eeefe9c24d9021e7fc7c191d63ab7610bde4a4eabbb1fb0f3e041bf78399"
-dependencies = [
- "aquamarine",
- "arrayref",
- "base64 0.22.1",
- "bincode",
- "blake3",
- "bv",
- "bytemuck",
- "byteorder",
- "bzip2",
- "crossbeam-channel",
- "dashmap",
- "dir-diff",
- "flate2",
- "fnv",
- "im",
- "index_list",
- "itertools 0.12.1",
- "lazy_static",
- "libc",
- "log",
- "lz4",
- "memmap2",
- "mockall",
- "modular-bitfield",
- "num-derive 0.4.2",
- "num-traits",
- "num_cpus",
- "num_enum",
- "percentage",
- "qualifier_attr",
- "rand 0.8.5",
- "rayon",
- "regex",
- "rustc_version",
- "serde",
- "serde_derive",
- "serde_json",
- "solana-accounts-db",
- "solana-address-lookup-table-program 2.0.1",
- "solana-bpf-loader-program",
- "solana-bucket-map",
- "solana-compute-budget",
- "solana-compute-budget-program",
- "solana-config-program",
- "solana-cost-model",
- "solana-inline-spl",
- "solana-loader-v4-program",
- "solana-measure",
- "solana-metrics",
- "solana-perf",
- "solana-program-runtime",
- "solana-rayon-threadlimit",
- "solana-sdk",
- "solana-stake-program",
- "solana-svm",
- "solana-system-program",
- "solana-transaction-status",
- "solana-version",
- "solana-vote",
- "solana-vote-program",
- "solana-zk-elgamal-proof-program",
- "solana-zk-sdk",
- "solana-zk-token-proof-program",
- "solana-zk-token-sdk",
- "static_assertions",
- "strum",
- "strum_macros",
- "symlink",
- "tar",
- "tempfile",
- "thiserror",
- "zstd",
 ]
 
 [[package]]
@@ -4693,7 +2879,7 @@ dependencies = [
  "serde_json",
  "serde_with 2.3.3",
  "sha2 0.10.8",
- "sha3 0.10.8",
+ "sha3",
  "siphasher",
  "solana-program 2.0.1",
  "solana-sdk-macro 2.0.1",
@@ -4729,104 +2915,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-security-txt"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
-
-[[package]]
-name = "solana-send-transaction-service"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73080903b1df6971cc7d486488b7f990fa9bcf2e2d9d1dbbabac35864d804088"
-dependencies = [
- "crossbeam-channel",
- "log",
- "solana-client",
- "solana-measure",
- "solana-metrics",
- "solana-runtime",
- "solana-sdk",
- "solana-tpu-client",
-]
-
-[[package]]
-name = "solana-stake-program"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02588aee6372c3e98a4d765efab6b98ea515e5ed51c1336ecc4e72e5cdf4ac75"
-dependencies = [
- "bincode",
- "log",
- "rustc_version",
- "solana-config-program",
- "solana-program-runtime",
- "solana-sdk",
- "solana-type-overrides",
- "solana-vote-program",
-]
-
-[[package]]
-name = "solana-streamer"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be38cba86a24f96a4de90ff55d013e15e12e80bedb1cc5cac3f588a6d5e17ed"
-dependencies = [
- "async-channel",
- "bytes",
- "crossbeam-channel",
- "dashmap",
- "futures-util",
- "histogram",
- "indexmap 2.2.6",
- "itertools 0.12.1",
- "libc",
- "log",
- "nix",
- "pem",
- "percentage",
- "quinn",
- "quinn-proto",
- "rand 0.8.5",
- "rustls",
- "smallvec",
- "solana-measure",
- "solana-metrics",
- "solana-perf",
- "solana-sdk",
- "solana-transaction-metrics-tracker",
- "thiserror",
- "tokio",
- "x509-parser",
-]
-
-[[package]]
-name = "solana-svm"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a923a2aacf962c0906cc5f7f39fa5e121543bb155b7c974ffdf6d7f0a39aec22"
-dependencies = [
- "itertools 0.12.1",
- "log",
- "percentage",
- "prost-build",
- "qualifier_attr",
- "rustc_version",
- "serde",
- "serde_derive",
- "solana-bpf-loader-program",
- "solana-compute-budget",
- "solana-loader-v4-program",
- "solana-measure",
- "solana-metrics",
- "solana-program-runtime",
- "solana-sdk",
- "solana-system-program",
- "solana-type-overrides",
- "solana-vote",
-]
-
-[[package]]
 name = "solana-system-program"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4842,88 +2930,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-thin-client"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace093fb66a27045b9026bb66273eea68fa93de6f9911caa6deb724c6ce6ef27"
-dependencies = [
- "bincode",
- "log",
- "rayon",
- "solana-connection-cache",
- "solana-rpc-client",
- "solana-rpc-client-api",
- "solana-sdk",
-]
-
-[[package]]
-name = "solana-tpu-client"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3f11bceb7cd61a607cbe45d76ac768106bfc6ca95ee4d0eaf9a9cd95de24c4"
-dependencies = [
- "async-trait",
- "bincode",
- "futures-util",
- "indexmap 2.2.6",
- "indicatif",
- "log",
- "rayon",
- "solana-connection-cache",
- "solana-measure",
- "solana-metrics",
- "solana-pubsub-client",
- "solana-rpc-client",
- "solana-rpc-client-api",
- "solana-sdk",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "solana-transaction-metrics-tracker"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ae0fea8d585c06692eaf09f2a042d5691a77016b7ea2eb7fde71eb75319bd0"
-dependencies = [
- "Inflector",
- "base64 0.22.1",
- "bincode",
- "lazy_static",
- "log",
- "rand 0.8.5",
- "solana-perf",
- "solana-sdk",
-]
-
-[[package]]
-name = "solana-transaction-status"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91a8938f050c4e1db66ca95c7476d934e1d3ef0a6f78a212276cb6cd01cf8e5"
-dependencies = [
- "Inflector",
- "base64 0.22.1",
- "bincode",
- "borsh 1.5.1",
- "bs58 0.5.1",
- "lazy_static",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "solana-account-decoder",
- "solana-sdk",
- "spl-associated-token-account",
- "spl-memo",
- "spl-token",
- "spl-token-2022",
- "spl-token-group-interface",
- "spl-token-metadata-interface",
- "thiserror",
-]
-
-[[package]]
 name = "solana-type-overrides"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4931,35 +2937,6 @@ checksum = "37a5a6db71f2b1d264e8b8d747ee0f43dc9ff41c5ca51647ed290bab4dd15f5c"
 dependencies = [
  "lazy_static",
  "rand 0.8.5",
-]
-
-[[package]]
-name = "solana-udp-client"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a729615d5dfd1097dd1cbbd39c62d0e701b2efc20d43943f926c2dc6ed1f95a7"
-dependencies = [
- "async-trait",
- "solana-connection-cache",
- "solana-net-utils",
- "solana-sdk",
- "solana-streamer",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "solana-version"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc214c8fb792d7b01a014a7f1b5ebe1efc551c6ffa554dfa55107d75b7657b5b"
-dependencies = [
- "log",
- "rustc_version",
- "semver",
- "serde",
- "serde_derive",
- "solana-sdk",
 ]
 
 [[package]]
@@ -4975,114 +2952,6 @@ dependencies = [
  "serde_derive",
  "solana-sdk",
  "thiserror",
-]
-
-[[package]]
-name = "solana-vote-program"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e80043ab279573f5f804c8e650956dd95587a12a38694a78e38c2e317bb635c1"
-dependencies = [
- "bincode",
- "log",
- "num-derive 0.4.2",
- "num-traits",
- "rustc_version",
- "serde",
- "serde_derive",
- "solana-metrics",
- "solana-program 2.0.1",
- "solana-program-runtime",
- "solana-sdk",
- "thiserror",
-]
-
-[[package]]
-name = "solana-zk-elgamal-proof-program"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e4c68f1cd26c0d0bedeb4b7f216f0cfa92d8931949bcc7223275e082c3ae4"
-dependencies = [
- "bytemuck",
- "num-derive 0.4.2",
- "num-traits",
- "solana-program-runtime",
- "solana-sdk",
- "solana-zk-sdk",
-]
-
-[[package]]
-name = "solana-zk-sdk"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ba871fd3658717b0d97d58f847a3668bb44e39b68e62432b6c231b2342b188"
-dependencies = [
- "aes-gcm-siv",
- "base64 0.22.1",
- "bincode",
- "bytemuck",
- "bytemuck_derive",
- "curve25519-dalek",
- "itertools 0.12.1",
- "lazy_static",
- "merlin",
- "num-derive 0.4.2",
- "num-traits",
- "rand 0.7.3",
- "serde",
- "serde_derive",
- "serde_json",
- "sha3 0.9.1",
- "solana-program 2.0.1",
- "solana-sdk",
- "subtle",
- "thiserror",
- "zeroize",
-]
-
-[[package]]
-name = "solana-zk-token-proof-program"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e2cf04674a3b3bec6dbc3300c8bc625677c54a535a50eefcf1c77f2fa05e59"
-dependencies = [
- "bytemuck",
- "num-derive 0.4.2",
- "num-traits",
- "solana-program-runtime",
- "solana-sdk",
- "solana-zk-token-sdk",
-]
-
-[[package]]
-name = "solana-zk-token-sdk"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729f832ad0cca51f73909b5a9d375ee77c0e608e7474155bf39da30a33abd778"
-dependencies = [
- "aes-gcm-siv",
- "base64 0.22.1",
- "bincode",
- "bytemuck",
- "bytemuck_derive",
- "byteorder",
- "curve25519-dalek",
- "itertools 0.12.1",
- "lazy_static",
- "merlin",
- "num-derive 0.4.2",
- "num-traits",
- "rand 0.7.3",
- "serde",
- "serde_derive",
- "serde_json",
- "sha3 0.9.1",
- "solana-curve25519",
- "solana-program 2.0.1",
- "solana-sdk",
- "subtle",
- "thiserror",
- "zeroize",
 ]
 
 [[package]]
@@ -5106,101 +2975,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "spl-associated-token-account"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e688554bac5838217ffd1fab7845c573ff106b6336bf7d290db7c98d5a8efd"
-dependencies = [
- "assert_matches",
- "borsh 1.5.1",
- "num-derive 0.4.2",
- "num-traits",
- "solana-program 2.0.1",
- "spl-token",
- "spl-token-2022",
- "thiserror",
-]
-
-[[package]]
-name = "spl-discriminator"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d1814406e98b08c5cd02c1126f83fd407ad084adce0b05fda5730677822eac"
-dependencies = [
- "bytemuck",
- "solana-program 2.0.1",
- "spl-discriminator-derive",
-]
-
-[[package]]
-name = "spl-discriminator-derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e8418ea6269dcfb01c712f0444d2c75542c04448b480e87de59d2865edc750"
-dependencies = [
- "quote",
- "spl-discriminator-syn",
- "syn 2.0.68",
-]
-
-[[package]]
-name = "spl-discriminator-syn"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f05593b7ca9eac7caca309720f2eafb96355e037e6d373b909a80fe7b69b9"
-dependencies = [
- "proc-macro2",
- "quote",
- "sha2 0.10.8",
- "syn 2.0.68",
- "thiserror",
-]
-
-[[package]]
-name = "spl-memo"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e9bae02de3405079a057fe244c867a08f92d48327d231fc60da831f94caf0a"
-dependencies = [
- "solana-program 2.0.1",
-]
-
-[[package]]
-name = "spl-pod"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ce669f48cf2eca1ec518916d8725596bfb655beb1c74374cf71dc6cb773c9"
-dependencies = [
- "borsh 1.5.1",
- "bytemuck",
- "solana-program 2.0.1",
- "solana-zk-token-sdk",
- "spl-program-error 0.4.1",
-]
-
-[[package]]
-name = "spl-program-error"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49065093ea91f57b9b2bd81493ff705e2ad4e64507a07dbc02b085778e02770e"
-dependencies = [
- "num-derive 0.4.2",
- "num-traits",
- "solana-program 2.0.1",
- "spl-program-error-derive",
- "thiserror",
-]
 
 [[package]]
 name = "spl-program-error"
@@ -5228,171 +3005,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-tlv-account-resolution"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cace91ba08984a41556efe49cbf2edca4db2f577b649da7827d3621161784bf8"
-dependencies = [
- "bytemuck",
- "solana-program 2.0.1",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error 0.4.1",
- "spl-type-length-value",
-]
-
-[[package]]
-name = "spl-token"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ae123223633a389f95d1da9d49c2d0a50d499e7060b9624626a69e536ad2a4"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive 0.4.2",
- "num-traits",
- "num_enum",
- "solana-program 2.0.1",
- "thiserror",
-]
-
-[[package]]
-name = "spl-token-2022"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5412f99ae7ee6e0afde00defaa354e6228e47e30c0e3adf553e2e01e6abb584"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive 0.4.2",
- "num-traits",
- "num_enum",
- "solana-program 2.0.1",
- "solana-security-txt",
- "solana-zk-token-sdk",
- "spl-memo",
- "spl-pod",
- "spl-token",
- "spl-token-group-interface",
- "spl-token-metadata-interface",
- "spl-transfer-hook-interface",
- "spl-type-length-value",
- "thiserror",
-]
-
-[[package]]
-name = "spl-token-group-interface"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d419b5cfa3ee8e0f2386fd7e02a33b3ec8a7db4a9c7064a2ea24849dc4a273b6"
-dependencies = [
- "bytemuck",
- "solana-program 2.0.1",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error 0.4.1",
-]
-
-[[package]]
-name = "spl-token-metadata-interface"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30179c47e93625680dabb620c6e7931bd12d62af390f447bc7beb4a3a9b5feee"
-dependencies = [
- "borsh 1.5.1",
- "solana-program 2.0.1",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error 0.4.1",
- "spl-type-length-value",
-]
-
-[[package]]
-name = "spl-transfer-hook-interface"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a98359769cd988f7b35c02558daa56d496a7e3bd8626e61f90a7c757eedb9b"
-dependencies = [
- "arrayref",
- "bytemuck",
- "solana-program 2.0.1",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error 0.4.1",
- "spl-tlv-account-resolution",
- "spl-type-length-value",
-]
-
-[[package]]
-name = "spl-type-length-value"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422ce13429dbd41d2cee8a73931c05fda0b0c8ca156a8b0c19445642550bb61a"
-dependencies = [
- "bytemuck",
- "solana-program 2.0.1",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error 0.4.1",
-]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "symlink"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -5435,18 +3057,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
-
-[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5468,73 +3078,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tar"
-version = "0.4.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
-name = "tarpc"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38a012bed6fb9681d3bf71ffaa4f88f3b4b9ed3198cda6e4c8462d24d4bb80"
-dependencies = [
- "anyhow",
- "fnv",
- "futures",
- "humantime",
- "opentelemetry",
- "pin-project",
- "rand 0.8.5",
- "serde",
- "static_assertions",
- "tarpc-plugins",
- "thiserror",
- "tokio",
- "tokio-serde",
- "tokio-util 0.6.10",
- "tracing",
- "tracing-opentelemetry",
-]
-
-[[package]]
-name = "tarpc-plugins"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee42b4e559f17bce0385ebf511a7beb67d5cc33c12c96b7f4e9789919d9c10f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "task-local-extensions"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8"
-dependencies = [
- "pin-utils",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
-dependencies = [
- "cfg-if",
- "fastrand",
- "rustix",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5542,12 +3085,6 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "termtree"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-case"
@@ -5583,21 +3120,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
-
-[[package]]
 name = "thiserror"
 version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5615,16 +3137,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.68",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
-dependencies = [
- "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -5702,24 +3214,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "num_cpus",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
- "tokio-macros",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.68",
 ]
 
 [[package]]
@@ -5729,63 +3226,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-serde"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
-dependencies = [
- "bincode",
- "bytes",
- "educe",
- "futures-core",
- "futures-sink",
- "pin-project",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
-dependencies = [
- "futures-util",
- "log",
- "rustls",
- "tokio",
- "tokio-rustls",
- "tungstenite",
- "webpki-roots 0.25.4",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "slab",
  "tokio",
 ]
 
@@ -5840,21 +3280,8 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "log",
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.68",
 ]
 
 [[package]]
@@ -5864,31 +3291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
-version = "0.17.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbe89715c1dbbb790059e2565353978564924ee85017b5fff365c872ff6721f"
-dependencies = [
- "once_cell",
- "opentelemetry",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
-dependencies = [
- "sharded-slab",
- "thread_local",
- "tracing-core",
 ]
 
 [[package]]
@@ -5898,40 +3300,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.8.5",
- "rustls",
- "sha1",
- "thiserror",
- "url",
- "utf-8",
- "webpki-roots 0.24.0",
-]
-
-[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "unicase"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
 
 [[package]]
 name = "unicode-bidi"
@@ -5961,28 +3333,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
-name = "universal-hash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
-dependencies = [
- "crypto-common",
- "subtle",
-]
-
-[[package]]
 name = "unreachable"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5990,12 +3340,6 @@ checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 dependencies = [
  "void",
 ]
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -6025,24 +3369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6053,16 +3379,6 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
 
 [[package]]
 name = "want"
@@ -6163,30 +3479,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b291546d5d9d1eab74f069c77749f2cb8504a12caa20f0f2de93ddbf6f411888"
-dependencies = [
- "rustls-webpki",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
-]
 
 [[package]]
 name = "winapi"
@@ -6387,35 +3682,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "x509-parser"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
-dependencies = [
- "asn1-rs",
- "base64 0.13.1",
- "data-encoding",
- "der-parser",
- "lazy_static",
- "nom",
- "oid-registry",
- "rusticata-macros",
- "thiserror",
- "time",
-]
-
-[[package]]
-name = "xattr"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
-dependencies = [
- "libc",
- "linux-raw-sys",
- "rustix",
-]
-
-[[package]]
 name = "zerocopy"
 version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6453,33 +3719,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.68",
-]
-
-[[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.11+zstd.1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75652c55c0b6f3e6f12eb786fe1bc960396bf05a1eb3bf1f3691c3610ac2e6d4"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -26,7 +26,7 @@ solana-program = "2.0.1"
 spl-program-error = "0.5.0"
 
 [dev-dependencies]
-solana-program-test = "2.0.1"
+mollusk-svm = "0.0.3"
 solana-sdk = "2.0.1"
 test-case = "3.3.1"
 

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -26,7 +26,7 @@ solana-program = "2.0.1"
 spl-program-error = "0.5.0"
 
 [dev-dependencies]
-mollusk-svm = "0.0.3"
+mollusk-svm = "0.0.5"
 solana-sdk = "2.0.1"
 test-case = "3.3.1"
 

--- a/program/tests/close_lookup_table_ix.rs
+++ b/program/tests/close_lookup_table_ix.rs
@@ -1,103 +1,99 @@
 #![cfg(feature = "test-sbf")]
 
+mod common;
+
 use {
-    common::{
-        add_lookup_table_account, assert_ix_error, new_address_lookup_table,
-        overwrite_slot_hashes_with_slots, setup_test_context,
-    },
+    common::{lookup_table_account, new_address_lookup_table, setup},
+    mollusk_svm::result::Check,
     solana_address_lookup_table_program::instruction::close_lookup_table,
-    solana_program_test::*,
     solana_sdk::{
-        clock::Clock,
-        instruction::InstructionError,
-        pubkey::Pubkey,
-        signature::{Keypair, Signer},
-        transaction::Transaction,
+        account::AccountSharedData, program_error::ProgramError, pubkey::Pubkey,
+        slot_hashes::MAX_ENTRIES,
     },
 };
 
-mod common;
-
-#[tokio::test]
-async fn test_close_lookup_table() {
+#[test]
+fn test_close_lookup_table() {
     // Succesfully close a deactived lookup table.
-    let mut context = setup_test_context().await;
+    let mut mollusk = setup();
+    mollusk.warp_to_slot(MAX_ENTRIES as u64 + 1);
 
-    context.warp_to_slot(2).unwrap();
-    overwrite_slot_hashes_with_slots(&context, &[]);
-
-    let lookup_table_address = Pubkey::new_unique();
-    let authority_keypair = Keypair::new();
+    let recipient = Pubkey::new_unique();
+    let authority = Pubkey::new_unique();
     let initialized_table = {
-        let mut table = new_address_lookup_table(Some(authority_keypair.pubkey()), 0);
-        table.meta.deactivation_slot = 1;
+        let mut table = new_address_lookup_table(Some(authority), 0);
+        table.meta.deactivation_slot = 0;
         table
     };
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
 
-    let client = &mut context.banks_client;
-    let payer = &context.payer;
-    let recent_blockhash = context.last_blockhash;
-    let transaction = Transaction::new_signed_with_payer(
-        &[close_lookup_table(
-            lookup_table_address,
-            authority_keypair.pubkey(),
-            context.payer.pubkey(),
-        )],
-        Some(&payer.pubkey()),
-        &[payer, &authority_keypair],
-        recent_blockhash,
+    let lookup_table_address = Pubkey::new_unique();
+    let lookup_table_account = lookup_table_account(initialized_table);
+
+    mollusk.process_and_validate_instruction(
+        &close_lookup_table(lookup_table_address, authority, recipient),
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+            (recipient, AccountSharedData::default()),
+        ],
+        &[
+            Check::success(),
+            // Because lookup tables are not reassigned to the System program,
+            // we can't just check for the canonical "closed" here.
+            Check::account(&lookup_table_address)
+                .data(&[])
+                .lamports(0)
+                .owner(&solana_address_lookup_table_program::id())
+                .build(),
+        ],
     );
-
-    assert!(matches!(
-        client.process_transaction(transaction).await,
-        Ok(())
-    ));
-    assert!(client
-        .get_account(lookup_table_address)
-        .await
-        .unwrap()
-        .is_none());
 }
 
-#[tokio::test]
-async fn test_close_lookup_table_not_deactivated() {
+#[test]
+fn test_close_lookup_table_not_deactivated() {
     // Try to close a lookup table that hasn't first been deactivated.
     // No matter the slot, this will fail, since the lookup table must first
     // be deactived before it can be closed.
-    let mut context = setup_test_context().await;
+    let mollusk = setup();
 
-    let authority_keypair = Keypair::new();
-    let initialized_table = new_address_lookup_table(Some(authority_keypair.pubkey()), 0);
+    let recipient = Pubkey::new_unique();
+    let authority = Pubkey::new_unique();
+    let initialized_table = new_address_lookup_table(Some(authority), 0);
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
-    let ix = close_lookup_table(
-        lookup_table_address,
-        authority_keypair.pubkey(),
-        context.payer.pubkey(),
+    mollusk.process_and_validate_instruction(
+        &close_lookup_table(lookup_table_address, authority, recipient),
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+            (recipient, AccountSharedData::default()),
+        ],
+        &[
+            // The ix should fail because the table hasn't been deactivated yet
+            Check::err(ProgramError::InvalidArgument),
+        ],
     );
-
-    // The ix should fail because the table hasn't been deactivated yet
-    assert_ix_error(
-        &mut context,
-        ix.clone(),
-        Some(&authority_keypair),
-        InstructionError::InvalidArgument,
-    )
-    .await;
 }
 
-#[tokio::test]
-async fn test_close_lookup_table_deactivated() {
+#[test]
+fn test_close_lookup_table_deactivated() {
     // Try to close a lookup table that was deactivated, but the cooldown
     // period hasn't expired yet.
     // This should fail because the table must be deactivated in a previous
     // slot and the cooldown period must expire before it can be closed.
-    let mut context = setup_test_context().await;
+    let mut mollusk = setup();
 
-    let authority_keypair = Keypair::new();
+    let recipient = Pubkey::new_unique();
+    let authority = Pubkey::new_unique();
 
+    // [Core BPF]: The original builtin implementation was relying on the fact
+    // that the `SlotHashes` sysvar is initialized to have an entry for slot 0.
+    // Program-Test does this to provide a more realistic test environment.
+    // That means this test was running with the `Clock` current slot at 1.
+    // In this implementation, we adapt the deactivation slot as well as the
+    // current slot into tweakable test case values.
     for (deactivation_slot, current_slot) in [
         (1, 1),                 // Deactivated in the same slot
         (1, 2),                 // Deactivated one slot earlier
@@ -112,110 +108,124 @@ async fn test_close_lookup_table_deactivated() {
         (10_000, 10_000 + 115), // Arbitrary number within cooldown.
         (10_000, 10_000 + 511), // At the very edge of cooldown.
     ] {
-        // Unfortunately, Program-Test's `warp_to_slot` causes an accounts hash
-        // mismatch if you try to warp after setting an account, so we have to just
-        // manipulate the `Clock` directly here.
-        let mut clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
-        clock.slot = current_slot;
-        context.set_sysvar::<Clock>(&clock);
-        overwrite_slot_hashes_with_slots(&context, &[deactivation_slot]);
+        mollusk.warp_to_slot(current_slot);
 
         let initialized_table = {
-            let mut table = new_address_lookup_table(Some(authority_keypair.pubkey()), 0);
+            let mut table = new_address_lookup_table(Some(authority), 0);
             table.meta.deactivation_slot = deactivation_slot;
             table
         };
+
         let lookup_table_address = Pubkey::new_unique();
-        add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+        let lookup_table_account = lookup_table_account(initialized_table);
 
-        let ix = close_lookup_table(
-            lookup_table_address,
-            authority_keypair.pubkey(),
-            context.payer.pubkey(),
-        );
-
+        // [Core BPF]: This still holds true while using `Clock`.
+        // Context sets up the slot hashes sysvar to _not_ have an entry for
+        // the current slot, which is when the table was deactivated.
+        //
+        // When the curent slot from `Clock` is the same as the deactivation
+        // slot, `LookupTableMeta::status()` should evaluate to this branch:
+        //
+        // ```rust
+        // else if self.deactivation_slot == current_slot {
+        //     LookupTableStatus::Deactivating {
+        //         remaining_blocks: MAX_ENTRIES.saturating_add(1),
+        //     }
+        // ````
+        //
+        // When the deactivation slot is a prior slot, but the cooldown period
+        // hasn't expired yet,`LookupTableMeta::status()` should evaluate to
+        // this branch:
+        //
+        // ```rust
+        // else if let Some(slot_position) =
+        //     calculate_slot_position(&self.deactivation_slot, &current_slot)
+        // {
+        //     LookupTableStatus::Deactivating {
+        //         remaining_blocks: MAX_ENTRIES.saturating_sub(slot_position),
+        //     }
+        // ````
+        //
         // Because the response is not `LookupTableStatus::Deactivated`, the ix
         // should fail.
-        assert_ix_error(
-            &mut context,
-            ix,
-            Some(&authority_keypair),
-            InstructionError::InvalidArgument,
-        )
-        .await;
+        mollusk.process_and_validate_instruction(
+            &close_lookup_table(lookup_table_address, authority, recipient),
+            &[
+                (lookup_table_address, lookup_table_account),
+                (authority, AccountSharedData::default()),
+                (recipient, AccountSharedData::default()),
+            ],
+            &[Check::err(ProgramError::InvalidArgument)],
+        );
     }
 }
 
-#[tokio::test]
-async fn test_close_immutable_lookup_table() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_close_immutable_lookup_table() {
+    let mollusk = setup();
 
-    let initialized_table = new_address_lookup_table(None, 10);
+    let recipient = Pubkey::new_unique();
+    let authority = Pubkey::new_unique();
+    let initialized_table = new_address_lookup_table(None, 0);
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
-    let authority = Keypair::new();
-    let ix = close_lookup_table(
-        lookup_table_address,
-        authority.pubkey(),
-        Pubkey::new_unique(),
+    mollusk.process_and_validate_instruction(
+        &close_lookup_table(lookup_table_address, authority, recipient),
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+            (recipient, AccountSharedData::default()),
+        ],
+        &[Check::err(ProgramError::Immutable)],
     );
-
-    assert_ix_error(
-        &mut context,
-        ix,
-        Some(&authority),
-        InstructionError::Immutable,
-    )
-    .await;
 }
 
-#[tokio::test]
-async fn test_close_lookup_table_with_wrong_authority() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_close_lookup_table_with_wrong_authority() {
+    let mollusk = setup();
 
-    let authority = Keypair::new();
-    let wrong_authority = Keypair::new();
-    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
+    let recipient = Pubkey::new_unique();
+    let authority = Pubkey::new_unique();
+    let wrong_authority = Pubkey::new_unique();
+    let initialized_table = new_address_lookup_table(Some(authority), 0);
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table.clone());
 
-    let ix = close_lookup_table(
-        lookup_table_address,
-        wrong_authority.pubkey(),
-        Pubkey::new_unique(),
+    mollusk.process_and_validate_instruction(
+        &close_lookup_table(lookup_table_address, authority, recipient),
+        &[
+            (lookup_table_address, lookup_table_account),
+            (wrong_authority, AccountSharedData::default()),
+            (recipient, AccountSharedData::default()),
+        ],
+        &[Check::err(ProgramError::IncorrectAuthority)],
     );
-
-    assert_ix_error(
-        &mut context,
-        ix,
-        Some(&wrong_authority),
-        InstructionError::IncorrectAuthority,
-    )
-    .await;
 }
 
-#[tokio::test]
-async fn test_close_lookup_table_without_signing() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_close_lookup_table_without_signing() {
+    let mollusk = setup();
 
-    let authority = Keypair::new();
-    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
+    let recipient = Pubkey::new_unique();
+    let authority = Pubkey::new_unique();
+    let initialized_table = new_address_lookup_table(Some(authority), 0);
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table.clone());
 
-    let mut ix = close_lookup_table(
-        lookup_table_address,
-        authority.pubkey(),
-        Pubkey::new_unique(),
+    let mut instruction = close_lookup_table(lookup_table_address, authority, recipient);
+    instruction.accounts[1].is_signer = false;
+
+    mollusk.process_and_validate_instruction(
+        &instruction,
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+            (recipient, AccountSharedData::default()),
+        ],
+        &[Check::err(ProgramError::MissingRequiredSignature)],
     );
-    ix.accounts[1].is_signer = false;
-
-    assert_ix_error(
-        &mut context,
-        ix,
-        None,
-        InstructionError::MissingRequiredSignature,
-    )
-    .await;
 }

--- a/program/tests/close_lookup_table_ix.rs
+++ b/program/tests/close_lookup_table_ix.rs
@@ -195,7 +195,7 @@ fn test_close_lookup_table_with_wrong_authority() {
     let lookup_table_account = lookup_table_account(initialized_table.clone());
 
     mollusk.process_and_validate_instruction(
-        &close_lookup_table(lookup_table_address, authority, recipient),
+        &close_lookup_table(lookup_table_address, wrong_authority, recipient),
         &[
             (lookup_table_address, lookup_table_account),
             (wrong_authority, AccountSharedData::default()),

--- a/program/tests/close_lookup_table_ix.rs
+++ b/program/tests/close_lookup_table_ix.rs
@@ -189,7 +189,7 @@ fn test_close_lookup_table_with_wrong_authority() {
     let recipient = Pubkey::new_unique();
     let authority = Pubkey::new_unique();
     let wrong_authority = Pubkey::new_unique();
-    let initialized_table = new_address_lookup_table(Some(authority), 0);
+    let initialized_table = new_address_lookup_table(Some(authority), 10);
 
     let lookup_table_address = Pubkey::new_unique();
     let lookup_table_account = lookup_table_account(initialized_table.clone());
@@ -211,7 +211,7 @@ fn test_close_lookup_table_without_signing() {
 
     let recipient = Pubkey::new_unique();
     let authority = Pubkey::new_unique();
-    let initialized_table = new_address_lookup_table(Some(authority), 0);
+    let initialized_table = new_address_lookup_table(Some(authority), 10);
 
     let lookup_table_address = Pubkey::new_unique();
     let lookup_table_account = lookup_table_account(initialized_table.clone());

--- a/program/tests/common.rs
+++ b/program/tests/common.rs
@@ -2,60 +2,17 @@
 #![cfg(feature = "test-sbf")]
 
 use {
+    mollusk_svm::Mollusk,
     solana_address_lookup_table_program::state::{AddressLookupTable, LookupTableMeta},
-    solana_program_test::*,
-    solana_sdk::{
-        account::AccountSharedData,
-        clock::Slot,
-        hash::Hash,
-        instruction::{Instruction, InstructionError},
-        pubkey::Pubkey,
-        signature::{Keypair, Signer},
-        slot_hashes::SlotHashes,
-        transaction::{Transaction, TransactionError},
-    },
+    solana_sdk::{account::AccountSharedData, pubkey::Pubkey, rent::Rent},
     std::borrow::Cow,
 };
 
-pub async fn setup_test_context() -> ProgramTestContext {
-    let mut program_test = ProgramTest::default();
-    program_test.add_upgradeable_program_to_genesis(
-        "solana_address_lookup_table_program",
+pub fn setup() -> Mollusk {
+    Mollusk::new(
         &solana_address_lookup_table_program::id(),
-    );
-    program_test.start_with_context().await
-}
-
-pub async fn assert_ix_error(
-    context: &mut ProgramTestContext,
-    ix: Instruction,
-    authority_keypair: Option<&Keypair>,
-    expected_err: InstructionError,
-) {
-    let client = &mut context.banks_client;
-    let payer = &context.payer;
-    let recent_blockhash = context.last_blockhash;
-
-    let mut signers = vec![payer];
-    if let Some(authority) = authority_keypair {
-        signers.push(authority);
-    }
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[ix],
-        Some(&payer.pubkey()),
-        &signers,
-        recent_blockhash,
-    );
-
-    assert_eq!(
-        client
-            .process_transaction(transaction)
-            .await
-            .unwrap_err()
-            .unwrap(),
-        TransactionError::InstructionError(0, expected_err),
-    );
+        "solana_address_lookup_table_program",
+    )
 }
 
 pub fn new_address_lookup_table(
@@ -73,30 +30,16 @@ pub fn new_address_lookup_table(
     }
 }
 
-pub async fn add_lookup_table_account(
-    context: &mut ProgramTestContext,
-    account_address: Pubkey,
+pub fn lookup_table_account(
     address_lookup_table: AddressLookupTable<'static>,
 ) -> AccountSharedData {
     let data = address_lookup_table.serialize_for_tests().unwrap();
-    let rent = context.banks_client.get_rent().await.unwrap();
-    let rent_exempt_balance = rent.minimum_balance(data.len());
-
+    let rent_exempt_balance = Rent::default().minimum_balance(data.len());
     let mut account = AccountSharedData::new(
         rent_exempt_balance,
         data.len(),
         &solana_address_lookup_table_program::id(),
     );
     account.set_data_from_slice(&data);
-    context.set_account(&account_address, &account);
-
     account
-}
-
-pub fn overwrite_slot_hashes_with_slots(context: &ProgramTestContext, slots: &[Slot]) {
-    let mut slot_hashes = SlotHashes::default();
-    for slot in slots {
-        slot_hashes.add(*slot, Hash::new_unique());
-    }
-    context.set_sysvar(&slot_hashes);
 }

--- a/program/tests/create_lookup_table_ix.rs
+++ b/program/tests/create_lookup_table_ix.rs
@@ -94,19 +94,17 @@ fn test_create_lookup_table_use_payer_as_authority() {
     mollusk.warp_to_slot(test_recent_slot + 1);
 
     let payer = Pubkey::new_unique();
-    let authority = Pubkey::new_unique();
+    let payer_account = AccountSharedData::new(100_000_000, 0, &system_program::id());
+
     let (create_lookup_table_ix, lookup_table_address) =
-        create_lookup_table(authority, payer, test_recent_slot);
+        create_lookup_table(payer, payer, test_recent_slot);
 
     mollusk.process_and_validate_instruction(
         &create_lookup_table_ix,
         &[
             (lookup_table_address, AccountSharedData::default()),
-            (authority, AccountSharedData::default()),
-            (
-                payer,
-                AccountSharedData::new(100_000_000, 0, &system_program::id()),
-            ),
+            (payer, payer_account.clone()),
+            (payer, payer_account),
             keyed_account_for_system_program(),
         ],
         &[Check::success()],

--- a/program/tests/deactivate_lookup_table_ix.rs
+++ b/program/tests/deactivate_lookup_table_ix.rs
@@ -1,149 +1,133 @@
 #![cfg(feature = "test-sbf")]
 
+mod common;
+
 use {
-    common::{
-        add_lookup_table_account, assert_ix_error, new_address_lookup_table, setup_test_context,
-    },
+    common::{lookup_table_account, new_address_lookup_table, setup},
+    mollusk_svm::result::Check,
     solana_address_lookup_table_program::{
         instruction::deactivate_lookup_table, state::AddressLookupTable,
     },
-    solana_program_test::*,
     solana_sdk::{
-        instruction::InstructionError,
+        account::{AccountSharedData, ReadableAccount},
+        program_error::ProgramError,
         pubkey::Pubkey,
-        signature::{Keypair, Signer},
-        transaction::Transaction,
     },
 };
 
-mod common;
+#[test]
+fn test_deactivate_lookup_table() {
+    let mollusk = setup();
 
-#[tokio::test]
-async fn test_deactivate_lookup_table() {
-    let mut context = setup_test_context().await;
+    let authority = Pubkey::new_unique();
+    let mut initialized_table = new_address_lookup_table(Some(authority), 10);
 
-    let authority = Keypair::new();
-    let mut initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(
-        &mut context,
-        lookup_table_address,
-        initialized_table.clone(),
-    )
-    .await;
+    let lookup_table_account = lookup_table_account(initialized_table.clone());
 
-    let client = &mut context.banks_client;
-    let payer = &context.payer;
-    let recent_blockhash = context.last_blockhash;
-    let transaction = Transaction::new_signed_with_payer(
-        &[deactivate_lookup_table(
-            lookup_table_address,
-            authority.pubkey(),
-        )],
-        Some(&payer.pubkey()),
-        &[payer, &authority],
-        recent_blockhash,
+    let result = mollusk.process_and_validate_instruction(
+        &deactivate_lookup_table(lookup_table_address, authority),
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+        ],
+        &[Check::success()],
     );
 
-    assert!(matches!(
-        client.process_transaction(transaction).await,
-        Ok(())
-    ));
-    let table_account = client
-        .get_account(lookup_table_address)
-        .await
-        .unwrap()
-        .unwrap();
-    let lookup_table = AddressLookupTable::deserialize(&table_account.data).unwrap();
-    assert_eq!(lookup_table.meta.deactivation_slot, 1);
+    let lookup_table_account = result.get_account(&lookup_table_address).unwrap();
+
+    let lookup_table = AddressLookupTable::deserialize(&lookup_table_account.data()).unwrap();
+    assert_eq!(lookup_table.meta.deactivation_slot, 0);
 
     // Check that only the deactivation slot changed
-    initialized_table.meta.deactivation_slot = 1;
+    initialized_table.meta.deactivation_slot = 0;
     assert_eq!(initialized_table, lookup_table);
 }
 
-#[tokio::test]
-async fn test_deactivate_immutable_lookup_table() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_deactivate_immutable_lookup_table() {
+    let mollusk = setup();
 
+    let authority = Pubkey::new_unique();
     let initialized_table = new_address_lookup_table(None, 10);
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
-    let authority = Keypair::new();
-    let ix = deactivate_lookup_table(lookup_table_address, authority.pubkey());
-
-    assert_ix_error(
-        &mut context,
-        ix,
-        Some(&authority),
-        InstructionError::Immutable,
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &deactivate_lookup_table(lookup_table_address, authority),
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+        ],
+        &[Check::err(ProgramError::Immutable)],
+    );
 }
 
-#[tokio::test]
-async fn test_deactivate_already_deactivated() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_deactivate_already_deactivated() {
+    let mollusk = setup();
 
-    let authority = Keypair::new();
+    let authority = Pubkey::new_unique();
     let initialized_table = {
-        let mut table = new_address_lookup_table(Some(authority.pubkey()), 0);
+        let mut table = new_address_lookup_table(Some(authority), 0);
         table.meta.deactivation_slot = 0;
         table
     };
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
-    let ix = deactivate_lookup_table(lookup_table_address, authority.pubkey());
-
-    assert_ix_error(
-        &mut context,
-        ix,
-        Some(&authority),
-        InstructionError::InvalidArgument,
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &deactivate_lookup_table(lookup_table_address, authority),
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+        ],
+        &[Check::err(ProgramError::InvalidArgument)],
+    );
 }
 
-#[tokio::test]
-async fn test_deactivate_lookup_table_with_wrong_authority() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_deactivate_lookup_table_with_wrong_authority() {
+    let mollusk = setup();
 
-    let authority = Keypair::new();
-    let wrong_authority = Keypair::new();
-    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
+    let authority = Pubkey::new_unique();
+    let wrong_authority = Pubkey::new_unique();
+    let initialized_table = new_address_lookup_table(Some(authority), 10);
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
-    let ix = deactivate_lookup_table(lookup_table_address, wrong_authority.pubkey());
-
-    assert_ix_error(
-        &mut context,
-        ix,
-        Some(&wrong_authority),
-        InstructionError::IncorrectAuthority,
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &deactivate_lookup_table(lookup_table_address, wrong_authority),
+        &[
+            (lookup_table_address, lookup_table_account),
+            (wrong_authority, AccountSharedData::default()),
+        ],
+        &[Check::err(ProgramError::IncorrectAuthority)],
+    );
 }
 
-#[tokio::test]
-async fn test_deactivate_lookup_table_without_signing() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_deactivate_lookup_table_without_signing() {
+    let mollusk = setup();
 
-    let authority = Keypair::new();
-    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
+    let authority = Pubkey::new_unique();
+    let initialized_table = new_address_lookup_table(Some(authority), 10);
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
-    let mut ix = deactivate_lookup_table(lookup_table_address, authority.pubkey());
-    ix.accounts[1].is_signer = false;
+    let mut instruction = deactivate_lookup_table(lookup_table_address, authority);
+    instruction.accounts[1].is_signer = false;
 
-    assert_ix_error(
-        &mut context,
-        ix,
-        None,
-        InstructionError::MissingRequiredSignature,
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &instruction,
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+        ],
+        &[Check::err(ProgramError::MissingRequiredSignature)],
+    );
 }

--- a/program/tests/extend_lookup_table_ix.rs
+++ b/program/tests/extend_lookup_table_ix.rs
@@ -1,26 +1,27 @@
 #![cfg(feature = "test-sbf")]
 
+mod common;
+
 use {
-    common::{
-        add_lookup_table_account, assert_ix_error, new_address_lookup_table, setup_test_context,
+    common::{lookup_table_account, new_address_lookup_table, setup},
+    mollusk_svm::{
+        program::keyed_account_for_system_program,
+        result::{Check, ProgramResult},
+        Mollusk,
     },
     solana_address_lookup_table_program::{
         instruction::extend_lookup_table,
         state::{AddressLookupTable, LookupTableMeta},
     },
-    solana_program_test::*,
     solana_sdk::{
-        account::{ReadableAccount, WritableAccount},
-        clock::Clock,
-        instruction::{Instruction, InstructionError},
+        account::{AccountSharedData, ReadableAccount, WritableAccount},
+        instruction::Instruction,
+        program_error::ProgramError,
         pubkey::{Pubkey, PUBKEY_BYTES},
-        signature::{Keypair, Signer},
-        transaction::{Transaction, TransactionError},
+        system_program,
     },
     std::{borrow::Cow, result::Result},
 };
-
-mod common;
 
 struct ExpectedTableAccount {
     lamports: u64,
@@ -28,98 +29,86 @@ struct ExpectedTableAccount {
     state: AddressLookupTable<'static>,
 }
 
-struct TestCase<'a> {
+struct TestCase {
     lookup_table_address: Pubkey,
     instruction: Instruction,
-    extra_signer: Option<&'a Keypair>,
-    expected_result: Result<ExpectedTableAccount, InstructionError>,
+    accounts: Vec<(Pubkey, AccountSharedData)>,
+    expected_result: Result<ExpectedTableAccount, ProgramError>,
 }
 
-async fn run_test_case(context: &mut ProgramTestContext, test_case: TestCase<'_>) {
-    let client = &mut context.banks_client;
-    let payer = &context.payer;
-    let recent_blockhash = context.last_blockhash;
-
-    let mut signers = vec![payer];
-    if let Some(extra_signer) = test_case.extra_signer {
-        signers.push(extra_signer);
-    }
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[test_case.instruction],
-        Some(&payer.pubkey()),
-        &signers,
-        recent_blockhash,
-    );
-
-    let process_result = client.process_transaction(transaction).await;
+fn run_test_case(mollusk: &Mollusk, test_case: TestCase) {
+    let result = mollusk.process_instruction(&test_case.instruction, &test_case.accounts);
 
     match test_case.expected_result {
         Ok(expected_account) => {
-            assert!(matches!(process_result, Ok(())));
+            assert!(matches!(result.program_result, ProgramResult::Success));
 
-            let table_account = client
-                .get_account(test_case.lookup_table_address)
-                .await
-                .unwrap()
-                .unwrap();
-
-            let lookup_table = AddressLookupTable::deserialize(&table_account.data).unwrap();
+            let table_account = result.get_account(&test_case.lookup_table_address).unwrap();
+            let lookup_table = AddressLookupTable::deserialize(&table_account.data()).unwrap();
             assert_eq!(lookup_table, expected_account.state);
             assert_eq!(table_account.lamports(), expected_account.lamports);
             assert_eq!(table_account.data().len(), expected_account.data_len);
         }
         Err(expected_err) => {
-            assert_eq!(
-                process_result.unwrap_err().unwrap(),
-                TransactionError::InstructionError(0, expected_err),
-            );
+            assert_eq!(result.program_result, ProgramResult::Failure(expected_err));
         }
     }
 }
 
-#[tokio::test]
-async fn test_extend_lookup_table() {
-    let mut context = setup_test_context().await;
-    let authority = Keypair::new();
+#[test]
+fn test_extend_lookup_table() {
+    let mut mollusk = setup();
+    mollusk.warp_to_slot(1); // Mollusk starts at slot 0, where program-test would start at 1.
+
+    let payer = Pubkey::new_unique();
+    let authority = Pubkey::new_unique();
     let current_bank_slot = 1;
-    let rent = context.banks_client.get_rent().await.unwrap();
+    let rent = mollusk.sysvars.rent.clone();
 
     for extend_same_slot in [true, false] {
         for (num_existing_addresses, num_new_addresses, expected_result) in [
-            (0, 0, Err(InstructionError::InvalidInstructionData)),
+            (0, 0, Err(ProgramError::InvalidInstructionData)),
             (0, 1, Ok(())),
             (0, 10, Ok(())),
             (0, 38, Ok(())), // Max new addresses allowed by `limited_deserialize`
-            (0, 39, Err(InstructionError::InvalidInstructionData)),
+            (0, 39, Err(ProgramError::InvalidInstructionData)),
             (1, 1, Ok(())),
             (1, 10, Ok(())),
             (218, 38, Ok(())), // 38 less than maximum, 38 brings it to the maximum
-            (219, 38, Err(InstructionError::InvalidInstructionData)),
+            (219, 38, Err(ProgramError::InvalidInstructionData)),
             (246, 10, Ok(())),
             (255, 1, Ok(())), // One less than maximum, 1 brings it to the maximum
-            (255, 2, Err(InstructionError::InvalidInstructionData)),
-            (256, 1, Err(InstructionError::InvalidArgument)),
+            (255, 2, Err(ProgramError::InvalidInstructionData)),
+            (256, 1, Err(ProgramError::InvalidArgument)),
         ] {
             let mut lookup_table =
-                new_address_lookup_table(Some(authority.pubkey()), num_existing_addresses);
+                new_address_lookup_table(Some(authority), num_existing_addresses);
             if extend_same_slot {
                 lookup_table.meta.last_extended_slot = current_bank_slot;
             }
 
             let lookup_table_address = Pubkey::new_unique();
-            let lookup_table_account =
-                add_lookup_table_account(&mut context, lookup_table_address, lookup_table.clone())
-                    .await;
+            let lookup_table_account = lookup_table_account(lookup_table.clone());
 
             let mut new_addresses = Vec::with_capacity(num_new_addresses);
             new_addresses.resize_with(num_new_addresses, Pubkey::new_unique);
+
             let instruction = extend_lookup_table(
                 lookup_table_address,
-                authority.pubkey(),
-                Some(context.payer.pubkey()),
+                authority,
+                Some(payer),
                 new_addresses.clone(),
             );
+
+            let accounts = vec![
+                (lookup_table_address, lookup_table_account.clone()),
+                (authority, AccountSharedData::default()),
+                (
+                    payer,
+                    AccountSharedData::new(100_000_000, 0, &system_program::id()),
+                ),
+                keyed_account_for_system_program(),
+            ];
 
             let mut expected_addresses: Vec<Pubkey> = lookup_table.addresses.to_vec();
             expected_addresses.extend(new_addresses);
@@ -152,201 +141,217 @@ async fn test_extend_lookup_table() {
             let test_case = TestCase {
                 lookup_table_address,
                 instruction,
-                extra_signer: Some(&authority),
+                accounts,
                 expected_result,
             };
 
-            run_test_case(&mut context, test_case).await;
+            run_test_case(&mollusk, test_case);
         }
     }
 }
 
-#[tokio::test]
-async fn test_extend_lookup_table_with_wrong_authority() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_extend_lookup_table_with_wrong_authority() {
+    let mollusk = setup();
 
-    let authority = Keypair::new();
-    let wrong_authority = Keypair::new();
-    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 0);
+    let payer = Pubkey::new_unique();
+    let authority = Pubkey::new_unique();
+    let wrong_authority = Pubkey::new_unique();
+
+    let initialized_table = new_address_lookup_table(Some(authority), 0);
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
     let new_addresses = vec![Pubkey::new_unique()];
-    let ix = extend_lookup_table(
+    let instruction = extend_lookup_table(
         lookup_table_address,
-        wrong_authority.pubkey(),
-        Some(context.payer.pubkey()),
+        wrong_authority,
+        Some(payer),
         new_addresses,
     );
 
-    assert_ix_error(
-        &mut context,
-        ix,
-        Some(&wrong_authority),
-        InstructionError::IncorrectAuthority,
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &instruction,
+        &[
+            (lookup_table_address, lookup_table_account),
+            (wrong_authority, AccountSharedData::default()),
+            (
+                payer,
+                AccountSharedData::new(100_000_000, 0, &system_program::id()),
+            ),
+            keyed_account_for_system_program(),
+        ],
+        &[Check::err(ProgramError::IncorrectAuthority)],
+    );
 }
 
-#[tokio::test]
-async fn test_extend_lookup_table_without_signing() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_extend_lookup_table_without_signing() {
+    let mollusk = setup();
 
-    let authority = Keypair::new();
-    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
+    let payer = Pubkey::new_unique();
+    let authority = Pubkey::new_unique();
+    let initialized_table = new_address_lookup_table(Some(authority), 10);
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
     let new_addresses = vec![Pubkey::new_unique()];
-    let mut ix = extend_lookup_table(
-        lookup_table_address,
-        authority.pubkey(),
-        Some(context.payer.pubkey()),
-        new_addresses,
-    );
-    ix.accounts[1].is_signer = false;
+    let mut instruction =
+        extend_lookup_table(lookup_table_address, authority, Some(payer), new_addresses);
+    instruction.accounts[1].is_signer = false;
 
-    assert_ix_error(
-        &mut context,
-        ix,
-        None,
-        InstructionError::MissingRequiredSignature,
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &instruction,
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+            (
+                payer,
+                AccountSharedData::new(100_000_000, 0, &system_program::id()),
+            ),
+            keyed_account_for_system_program(),
+        ],
+        &[Check::err(ProgramError::MissingRequiredSignature)],
+    );
 }
 
-#[tokio::test]
-async fn test_extend_deactivated_lookup_table() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_extend_deactivated_lookup_table() {
+    let mollusk = setup();
 
-    let authority = Keypair::new();
+    let payer = Pubkey::new_unique();
+    let authority = Pubkey::new_unique();
     let initialized_table = {
-        let mut table = new_address_lookup_table(Some(authority.pubkey()), 0);
+        let mut table = new_address_lookup_table(Some(authority), 0);
         table.meta.deactivation_slot = 0;
         table
     };
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
     let new_addresses = vec![Pubkey::new_unique()];
-    let ix = extend_lookup_table(
-        lookup_table_address,
-        authority.pubkey(),
-        Some(context.payer.pubkey()),
-        new_addresses,
-    );
+    let instruction =
+        extend_lookup_table(lookup_table_address, authority, Some(payer), new_addresses);
 
-    assert_ix_error(
-        &mut context,
-        ix,
-        Some(&authority),
-        InstructionError::InvalidArgument,
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &instruction,
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+            (
+                payer,
+                AccountSharedData::new(100_000_000, 0, &system_program::id()),
+            ),
+            keyed_account_for_system_program(),
+        ],
+        &[Check::err(ProgramError::InvalidArgument)],
+    );
 }
 
-#[tokio::test]
-async fn test_extend_immutable_lookup_table() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_extend_immutable_lookup_table() {
+    let mollusk = setup();
 
-    let authority = Keypair::new();
+    let payer = Pubkey::new_unique();
+    let authority = Pubkey::new_unique();
     let initialized_table = new_address_lookup_table(None, 1);
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
     let new_addresses = vec![Pubkey::new_unique()];
-    let ix = extend_lookup_table(
-        lookup_table_address,
-        authority.pubkey(),
-        Some(context.payer.pubkey()),
-        new_addresses,
-    );
+    let instruction =
+        extend_lookup_table(lookup_table_address, authority, Some(payer), new_addresses);
 
-    assert_ix_error(
-        &mut context,
-        ix,
-        Some(&authority),
-        InstructionError::Immutable,
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &instruction,
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+            (
+                payer,
+                AccountSharedData::new(100_000_000, 0, &system_program::id()),
+            ),
+            keyed_account_for_system_program(),
+        ],
+        &[Check::err(ProgramError::Immutable)],
+    );
 }
 
-#[tokio::test]
-async fn test_extend_lookup_table_without_payer() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_extend_lookup_table_without_payer() {
+    let mollusk = setup();
 
-    let authority = Keypair::new();
-    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 0);
+    let authority = Pubkey::new_unique();
+    let initialized_table = new_address_lookup_table(Some(authority), 0);
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
     let new_addresses = vec![Pubkey::new_unique()];
-    let ix = extend_lookup_table(
-        lookup_table_address,
-        authority.pubkey(),
-        None,
-        new_addresses,
-    );
+    let instruction = extend_lookup_table(lookup_table_address, authority, None, new_addresses);
 
-    assert_ix_error(
-        &mut context,
-        ix,
-        Some(&authority),
-        InstructionError::NotEnoughAccountKeys,
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &instruction,
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+        ],
+        &[Check::err(ProgramError::NotEnoughAccountKeys)],
+    );
 }
 
-#[tokio::test]
-async fn test_extend_prepaid_lookup_table_without_payer() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_extend_prepaid_lookup_table_without_payer() {
+    let mollusk = setup();
 
-    let authority = Keypair::new();
+    let authority = Pubkey::new_unique();
     let lookup_table_address = Pubkey::new_unique();
 
-    let expected_state = {
+    let (lookup_table_account, expected_state) = {
         // initialize lookup table
-        let empty_lookup_table = new_address_lookup_table(Some(authority.pubkey()), 0);
-        let mut lookup_table_account =
-            add_lookup_table_account(&mut context, lookup_table_address, empty_lookup_table).await;
+        let empty_lookup_table = new_address_lookup_table(Some(authority), 0);
+        let mut lookup_table_account = lookup_table_account(empty_lookup_table);
 
         // calculate required rent exempt balance for adding one address
-        let mut temp_lookup_table = new_address_lookup_table(Some(authority.pubkey()), 1);
+        let mut temp_lookup_table = new_address_lookup_table(Some(authority), 1);
         let data = temp_lookup_table.clone().serialize_for_tests().unwrap();
-        let rent = context.banks_client.get_rent().await.unwrap();
-        let rent_exempt_balance = rent.minimum_balance(data.len());
+        let rent_exempt_balance = mollusk.sysvars.rent.minimum_balance(data.len());
 
         // prepay for one address
         lookup_table_account.set_lamports(rent_exempt_balance);
-        context.set_account(&lookup_table_address, &lookup_table_account);
 
         // test will extend table in the current bank's slot
-        let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
-        temp_lookup_table.meta.last_extended_slot = clock.slot;
+        temp_lookup_table.meta.last_extended_slot = mollusk.sysvars.clock.slot;
 
-        ExpectedTableAccount {
-            lamports: rent_exempt_balance,
-            data_len: data.len(),
-            state: temp_lookup_table,
-        }
+        (
+            lookup_table_account,
+            ExpectedTableAccount {
+                lamports: rent_exempt_balance,
+                data_len: data.len(),
+                state: temp_lookup_table,
+            },
+        )
     };
 
     let new_addresses = expected_state.state.addresses.to_vec();
-    let instruction = extend_lookup_table(
-        lookup_table_address,
-        authority.pubkey(),
-        None,
-        new_addresses,
-    );
+    let instruction = extend_lookup_table(lookup_table_address, authority, None, new_addresses);
+
+    let accounts = vec![
+        (lookup_table_address, lookup_table_account),
+        (authority, AccountSharedData::default()),
+    ];
 
     run_test_case(
-        &mut context,
+        &mollusk,
         TestCase {
             lookup_table_address,
             instruction,
-            extra_signer: Some(&authority),
+            accounts,
             expected_result: Ok(expected_state),
         },
-    )
-    .await;
+    );
 }

--- a/program/tests/freeze_lookup_table_ix.rs
+++ b/program/tests/freeze_lookup_table_ix.rs
@@ -1,60 +1,42 @@
 #![cfg(feature = "test-sbf")]
 
+mod common;
+
 use {
-    common::{
-        add_lookup_table_account, assert_ix_error, new_address_lookup_table, setup_test_context,
-    },
+    common::{lookup_table_account, new_address_lookup_table, setup},
+    mollusk_svm::result::Check,
     solana_address_lookup_table_program::{
         instruction::freeze_lookup_table, state::AddressLookupTable,
     },
-    solana_program_test::*,
     solana_sdk::{
-        instruction::InstructionError,
+        account::{AccountSharedData, ReadableAccount},
+        program_error::ProgramError,
         pubkey::Pubkey,
-        signature::{Keypair, Signer},
-        transaction::Transaction,
     },
 };
 
-mod common;
+#[test]
+fn test_freeze_lookup_table() {
+    let mollusk = setup();
 
-#[tokio::test]
-async fn test_freeze_lookup_table() {
-    let mut context = setup_test_context().await;
+    let authority = Pubkey::new_unique();
+    let mut initialized_table = new_address_lookup_table(Some(authority), 10);
 
-    let authority = Keypair::new();
-    let mut initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(
-        &mut context,
-        lookup_table_address,
-        initialized_table.clone(),
-    )
-    .await;
+    let lookup_table_account = lookup_table_account(initialized_table.clone());
 
-    let client = &mut context.banks_client;
-    let payer = &context.payer;
-    let recent_blockhash = context.last_blockhash;
-    let transaction = Transaction::new_signed_with_payer(
-        &[freeze_lookup_table(
-            lookup_table_address,
-            authority.pubkey(),
-        )],
-        Some(&payer.pubkey()),
-        &[payer, &authority],
-        recent_blockhash,
+    let result = mollusk.process_and_validate_instruction(
+        &freeze_lookup_table(lookup_table_address, authority),
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+        ],
+        &[Check::success()],
     );
 
-    assert!(matches!(
-        client.process_transaction(transaction).await,
-        Ok(())
-    ));
-    let table_account = client
-        .get_account(lookup_table_address)
-        .await
-        .unwrap()
-        .unwrap();
-    let lookup_table = AddressLookupTable::deserialize(&table_account.data).unwrap();
+    let lookup_table_account = result.get_account(&lookup_table_address).unwrap();
+    let lookup_table = AddressLookupTable::deserialize(&lookup_table_account.data()).unwrap();
+
     assert_eq!(lookup_table.meta.authority, None);
 
     // Check that only the authority changed
@@ -62,108 +44,111 @@ async fn test_freeze_lookup_table() {
     assert_eq!(initialized_table, lookup_table);
 }
 
-#[tokio::test]
-async fn test_freeze_immutable_lookup_table() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_freeze_immutable_lookup_table() {
+    let mollusk = setup();
 
+    let authority = Pubkey::new_unique();
     let initialized_table = new_address_lookup_table(None, 10);
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
-    let authority = Keypair::new();
-    let ix = freeze_lookup_table(lookup_table_address, authority.pubkey());
-
-    assert_ix_error(
-        &mut context,
-        ix,
-        Some(&authority),
-        InstructionError::Immutable,
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &freeze_lookup_table(lookup_table_address, authority),
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+        ],
+        &[Check::err(ProgramError::Immutable)],
+    );
 }
 
-#[tokio::test]
-async fn test_freeze_deactivated_lookup_table() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_freeze_deactivated_lookup_table() {
+    let mollusk = setup();
 
-    let authority = Keypair::new();
+    let authority = Pubkey::new_unique();
     let initialized_table = {
-        let mut table = new_address_lookup_table(Some(authority.pubkey()), 10);
+        let mut table = new_address_lookup_table(Some(authority), 10);
         table.meta.deactivation_slot = 0;
         table
     };
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
-    let ix = freeze_lookup_table(lookup_table_address, authority.pubkey());
-
-    assert_ix_error(
-        &mut context,
-        ix,
-        Some(&authority),
-        InstructionError::InvalidArgument,
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &freeze_lookup_table(lookup_table_address, authority),
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+        ],
+        &[Check::err(ProgramError::InvalidArgument)],
+    );
 }
 
-#[tokio::test]
-async fn test_freeze_lookup_table_with_wrong_authority() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_freeze_lookup_table_with_wrong_authority() {
+    let mollusk = setup();
 
-    let authority = Keypair::new();
-    let wrong_authority = Keypair::new();
-    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
+    let authority = Pubkey::new_unique();
+    let wrong_authority = Pubkey::new_unique();
+
+    let initialized_table = new_address_lookup_table(Some(authority), 10);
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
-    let ix = freeze_lookup_table(lookup_table_address, wrong_authority.pubkey());
-
-    assert_ix_error(
-        &mut context,
-        ix,
-        Some(&wrong_authority),
-        InstructionError::IncorrectAuthority,
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &freeze_lookup_table(lookup_table_address, wrong_authority),
+        &[
+            (lookup_table_address, lookup_table_account),
+            (wrong_authority, AccountSharedData::default()),
+        ],
+        &[Check::err(ProgramError::IncorrectAuthority)],
+    );
 }
 
-#[tokio::test]
-async fn test_freeze_lookup_table_without_signing() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_freeze_lookup_table_without_signing() {
+    let mollusk = setup();
 
-    let authority = Keypair::new();
-    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 10);
+    let authority = Pubkey::new_unique();
+    let initialized_table = new_address_lookup_table(Some(authority), 10);
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
-    let mut ix = freeze_lookup_table(lookup_table_address, authority.pubkey());
-    ix.accounts[1].is_signer = false;
+    let mut instruction = freeze_lookup_table(lookup_table_address, authority);
+    instruction.accounts[1].is_signer = false;
 
-    assert_ix_error(
-        &mut context,
-        ix,
-        None,
-        InstructionError::MissingRequiredSignature,
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &instruction,
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+        ],
+        &[Check::err(ProgramError::MissingRequiredSignature)],
+    );
 }
 
-#[tokio::test]
-async fn test_freeze_empty_lookup_table() {
-    let mut context = setup_test_context().await;
+#[test]
+fn test_freeze_empty_lookup_table() {
+    let mollusk = setup();
 
-    let authority = Keypair::new();
-    let initialized_table = new_address_lookup_table(Some(authority.pubkey()), 0);
+    let authority = Pubkey::new_unique();
+    let initialized_table = new_address_lookup_table(Some(authority), 0);
+
     let lookup_table_address = Pubkey::new_unique();
-    add_lookup_table_account(&mut context, lookup_table_address, initialized_table).await;
+    let lookup_table_account = lookup_table_account(initialized_table);
 
-    let ix = freeze_lookup_table(lookup_table_address, authority.pubkey());
-
-    assert_ix_error(
-        &mut context,
-        ix,
-        Some(&authority),
-        InstructionError::InvalidInstructionData,
-    )
-    .await;
+    mollusk.process_and_validate_instruction(
+        &freeze_lookup_table(lookup_table_address, authority),
+        &[
+            (lookup_table_address, lookup_table_account),
+            (authority, AccountSharedData::default()),
+        ],
+        &[Check::err(ProgramError::InvalidInstructionData)],
+    );
 }


### PR DESCRIPTION
This PR rewrites all program tests with [Mollusk](https://github.com/buffalojoec/mollusk) instead of `solana-program-test`.

Note: The use of 0.0.3 instead of 0.0.2 is intentional, it includes [a fix for slot hashes](https://github.com/buffalojoec/mollusk/pull/24) on warped slots.