### PR TITLE
update linting configurations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1595,6 +1595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6dd100976df9dd59d0c3fecf6f9ad3f161a087374d1b2a77ebb4ad8920f11bb"
 dependencies = [
  "borsh 0.10.3",
+ "serde",
 ]
 
 [[package]]

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -10,7 +10,7 @@ license-file = "../../LICENSE"
 [features]
 anchor = ["dep:anchor-lang"]
 test-sbf = []
-serde = ["dep:serde", "dep:serde_with"]
+serde = ["dep:serde", "dep:serde_with", "kaigan/serde"]
 
 [dependencies]
 anchor-lang = { version = "0.30.0", optional = true }

--- a/clients/rust/src/generated/accounts/address_lookup_table.rs
+++ b/clients/rust/src/generated/accounts/address_lookup_table.rs
@@ -62,28 +62,3 @@ impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for AddressLook
         Self::deserialize(&mut data)
     }
 }
-
-#[cfg(feature = "anchor")]
-impl anchor_lang::AccountDeserialize for AddressLookupTable {
-    fn try_deserialize_unchecked(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
-        Ok(Self::deserialize(buf)?)
-    }
-}
-
-#[cfg(feature = "anchor")]
-impl anchor_lang::AccountSerialize for AddressLookupTable {}
-
-#[cfg(feature = "anchor")]
-impl anchor_lang::Owner for AddressLookupTable {
-    fn owner() -> Pubkey {
-        crate::ADDRESS_LOOKUP_TABLE_ID
-    }
-}
-
-#[cfg(feature = "anchor-idl-build")]
-impl anchor_lang::IdlBuild for AddressLookupTable {}
-
-#[cfg(feature = "anchor-idl-build")]
-impl anchor_lang::Discriminator for AddressLookupTable {
-    const DISCRIMINATOR: [u8; 8] = [0; 8];
-}

--- a/clients/rust/src/generated/instructions/close_lookup_table.rs
+++ b/clients/rust/src/generated/instructions/close_lookup_table.rs
@@ -222,7 +222,7 @@ impl<'a, 'b> CloseLookupTableCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(3 + 1 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(4 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.address.clone());
         account_infos.push(self.authority.clone());

--- a/clients/rust/src/generated/instructions/create_lookup_table.rs
+++ b/clients/rust/src/generated/instructions/create_lookup_table.rs
@@ -287,7 +287,7 @@ impl<'a, 'b> CreateLookupTableCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(4 + 1 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(5 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.address.clone());
         account_infos.push(self.authority.clone());

--- a/clients/rust/src/generated/instructions/deactivate_lookup_table.rs
+++ b/clients/rust/src/generated/instructions/deactivate_lookup_table.rs
@@ -203,7 +203,7 @@ impl<'a, 'b> DeactivateLookupTableCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(2 + 1 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(3 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.address.clone());
         account_infos.push(self.authority.clone());

--- a/clients/rust/src/generated/instructions/extend_lookup_table.rs
+++ b/clients/rust/src/generated/instructions/extend_lookup_table.rs
@@ -283,7 +283,7 @@ impl<'a, 'b> ExtendLookupTableCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(4 + 1 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(5 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.address.clone());
         account_infos.push(self.authority.clone());

--- a/clients/rust/src/generated/instructions/freeze_lookup_table.rs
+++ b/clients/rust/src/generated/instructions/freeze_lookup_table.rs
@@ -203,7 +203,7 @@ impl<'a, 'b> FreezeLookupTableCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(2 + 1 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(3 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.address.clone());
         account_infos.push(self.authority.clone());

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@codama/renderers-js": "^1.0.0",
-    "@codama/renderers-rust": "^1.0.0",
+    "@codama/renderers-rust": "^1.0.3",
     "@iarna/toml": "^2.2.5",
     "codama": "^1.0.0",
     "typescript": "^5.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
       '@codama/renderers-rust':
-        specifier: ^1.0.0
-        version: 1.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+        specifier: ^1.0.3
+        version: 1.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
       '@iarna/toml':
         specifier: ^2.2.5
         version: 2.2.5
@@ -48,8 +48,8 @@ packages:
   '@codama/renderers-js@1.0.0':
     resolution: {integrity: sha512-wi9eqrtLbTM49ELqKqxIgbTaf7xKMWT+HIqj6GN373G0OJnSKwUJPIXAGLO+RCls5DGjDuOE5svuThU0zBkfzA==}
 
-  '@codama/renderers-rust@1.0.0':
-    resolution: {integrity: sha512-2z+XN6KCTQFDfE30OQcRo2LW4+9dnYlqs8rSUhKO2YsRiCnOoMu/zrNSqLtjL84T2PAwReRq+vBifcE0zaOuRw==}
+  '@codama/renderers-rust@1.0.3':
+    resolution: {integrity: sha512-S2n+bq92q5YZ01Z+8klNNbvgVErKsJzUYWN0Y0rPymx2vwkHfTkeQHEOuckb/kzHJm9QGXrzkDtSDBy5EDS1Wg==}
 
   '@codama/validators@1.0.0':
     resolution: {integrity: sha512-jSfU5IrcGTvcqsJSBSzD3Ochig+hKKg2NKsT/vUfQ4jAw2cQrVUP5f4dMXyX779JYfHLHCwZnBYvgEdgi9gBZQ==}
@@ -441,7 +441,7 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@codama/renderers-rust@1.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
+  '@codama/renderers-rust@1.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
     dependencies:
       '@codama/errors': 1.0.0
       '@codama/nodes': 1.0.0

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -35,3 +35,11 @@ crate-type = ["cdylib", "lib"]
 
 [build-dependencies]
 rustc_version = "0.4"
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(target_os, values("solana"))',
+    'cfg(feature, values("min_specialization"))',
+    'cfg(RUSTC_WITH_SPECIALIZATION)',
+]

--- a/program/tests/create_lookup_table_ix.rs
+++ b/program/tests/create_lookup_table_ix.rs
@@ -64,7 +64,7 @@ fn test_create_lookup_table_idempotent() {
         lookup_table_account.lamports(),
         Rent::default().minimum_balance(LOOKUP_TABLE_META_SIZE)
     );
-    let lookup_table = AddressLookupTable::deserialize(&lookup_table_account.data()).unwrap();
+    let lookup_table = AddressLookupTable::deserialize(lookup_table_account.data()).unwrap();
     assert_eq!(lookup_table.meta.deactivation_slot, Slot::MAX);
     assert_eq!(lookup_table.meta.authority, Some(authority));
     assert_eq!(lookup_table.meta.last_extended_slot, 0);

--- a/program/tests/deactivate_lookup_table_ix.rs
+++ b/program/tests/deactivate_lookup_table_ix.rs
@@ -36,7 +36,7 @@ fn test_deactivate_lookup_table() {
 
     let lookup_table_account = result.get_account(&lookup_table_address).unwrap();
 
-    let lookup_table = AddressLookupTable::deserialize(&lookup_table_account.data()).unwrap();
+    let lookup_table = AddressLookupTable::deserialize(lookup_table_account.data()).unwrap();
     assert_eq!(lookup_table.meta.deactivation_slot, 0);
 
     // Check that only the deactivation slot changed

--- a/program/tests/extend_lookup_table_ix.rs
+++ b/program/tests/extend_lookup_table_ix.rs
@@ -44,7 +44,7 @@ fn run_test_case(mollusk: &Mollusk, test_case: TestCase) {
             assert!(matches!(result.program_result, ProgramResult::Success));
 
             let table_account = result.get_account(&test_case.lookup_table_address).unwrap();
-            let lookup_table = AddressLookupTable::deserialize(&table_account.data()).unwrap();
+            let lookup_table = AddressLookupTable::deserialize(table_account.data()).unwrap();
             assert_eq!(lookup_table, expected_account.state);
             assert_eq!(table_account.lamports(), expected_account.lamports);
             assert_eq!(table_account.data().len(), expected_account.data_len);

--- a/program/tests/freeze_lookup_table_ix.rs
+++ b/program/tests/freeze_lookup_table_ix.rs
@@ -35,7 +35,7 @@ fn test_freeze_lookup_table() {
     );
 
     let lookup_table_account = result.get_account(&lookup_table_address).unwrap();
-    let lookup_table = AddressLookupTable::deserialize(&lookup_table_account.data()).unwrap();
+    let lookup_table = AddressLookupTable::deserialize(lookup_table_account.data()).unwrap();
 
     assert_eq!(lookup_table.meta.authority, None);
 

--- a/scripts/client/lint-rust.mjs
+++ b/scripts/client/lint-rust.mjs
@@ -11,6 +11,7 @@ import {
 const lintArgs = [
   '-Zunstable-options',
   '--all-targets',
+  '--all-features',
   '--',
   '--deny=warnings',
   ...cliArguments(),

--- a/scripts/client/lint-rust.mjs
+++ b/scripts/client/lint-rust.mjs
@@ -10,6 +10,7 @@ import {
 // Configure arguments here.
 const lintArgs = [
   '-Zunstable-options',
+  '--all-targets',
   '--',
   '--deny=warnings',
   ...cliArguments(),

--- a/scripts/generate-clients.mjs
+++ b/scripts/generate-clients.mjs
@@ -22,6 +22,7 @@ codama.accept(
 const rustClient = path.join(__dirname, '..', 'clients', 'rust');
 codama.accept(
   renderRustVisitor(path.join(rustClient, 'src', 'generated'), {
+    anchorTraits: false,
     formatCode: true,
     crateFolder: rustClient,
     toolchain: getToolchainArgument('format'),

--- a/scripts/program/lint.mjs
+++ b/scripts/program/lint.mjs
@@ -11,8 +11,8 @@ import {
 // Configure arguments here.
 const lintArgs = [
   '-Zunstable-options',
-  '--features',
-  'bpf-entrypoint,test-sbf',
+  '--all-targets',
+  '--all-features',
   '--',
   '--deny=warnings',
   '--deny=clippy::arithmetic_side_effects',


### PR DESCRIPTION
#### Summary of Changes

Adds a config to the program's manifest for ignoring `unexpected_cfg` (like `target_os = "solana"`). Also adjusts the linting scripts to cover all targets and features.