### PR TITLE
rust: Bump nightly toolchain to match v2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ solana = "2.0.1"
 # Specify Rust toolchains for rustfmt, clippy, and build.
 # Any unprovided toolchains default to stable.
 [workspace.metadata.toolchains]
-format = "nightly-2023-10-05"
-lint = "nightly-2023-10-05"
+format = "nightly-2024-05-02"
+lint = "nightly-2024-05-02"


### PR DESCRIPTION
#### Problem

The Solana v2 crates lint / format against nightly-2024-05-02, but this repo is still using nightly-2023-10-05.

#### Summary of changes

Bump the lint / fmt toolchain to nightly-2024-05-02 to match.