### PR TITLE
program: safe deserialize instruction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2724,6 +2724,8 @@ dependencies = [
  "solana-frozen-abi-macro 2.0.1",
  "solana-program 2.0.1",
  "solana-sdk",
+ "strum",
+ "strum_macros",
  "test-case",
 ]
 
@@ -3163,6 +3165,25 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "subtle"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -28,6 +28,8 @@ solana-program = "2.0.1"
 mollusk-svm = { version = "0.0.5", features = ["fuzz"] }
 mollusk-svm-bencher = "0.0.5"
 solana-sdk = "2.0.1"
+strum = "0.24"
+strum_macros = "0.24"
 test-case = "3.3.1"
 
 [lib]

--- a/program/benches/compute_units.md
+++ b/program/benches/compute_units.md
@@ -1,3 +1,29 @@
+#### Compute Units: 2024-11-07 16:24:48.059441548 UTC
+
+| Name | CUs | Delta |
+|------|------|-------|
+| create_lookup_table | 10758 | +10 |
+| freeze_lookup_table | 1517 | +7 |
+| extend_lookup_table_from_0_to_1 | 6222 | +6 |
+| extend_lookup_table_from_0_to_10 | 8841 | -39 |
+| extend_lookup_table_from_0_to_38 | 17077 | -179 |
+| extend_lookup_table_from_1_to_2 | 6222 | +6 |
+| extend_lookup_table_from_1_to_10 | 8547 | -34 |
+| extend_lookup_table_from_1_to_39 | 17077 | -179 |
+| extend_lookup_table_from_5_to_6 | 6222 | +6 |
+| extend_lookup_table_from_5_to_15 | 8842 | -39 |
+| extend_lookup_table_from_5_to_43 | 17077 | -179 |
+| extend_lookup_table_from_25_to_26 | 6225 | +6 |
+| extend_lookup_table_from_25_to_35 | 8844 | -39 |
+| extend_lookup_table_from_25_to_63 | 17080 | -179 |
+| extend_lookup_table_from_50_to_88 | 17083 | -179 |
+| extend_lookup_table_from_100_to_138 | 17089 | -179 |
+| extend_lookup_table_from_150_to_188 | 17096 | -179 |
+| extend_lookup_table_from_200_to_238 | 17102 | -179 |
+| extend_lookup_table_from_255_to_256 | 6254 | +6 |
+| deactivate_lookup_table | 3151 | +8 |
+| close_lookup_table | 2226 | +6 |
+
 #### Compute Units: 2024-10-22 17:54:37.721198 UTC
 
 | Name | CUs | Delta |

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -10,6 +10,7 @@ use {
     },
 };
 
+#[cfg_attr(test, derive(strum_macros::EnumIter))]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum AddressLookupTableInstruction {
     /// Create an address lookup table

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -60,16 +60,56 @@ fn get_lookup_table_status(
     }
 }
 
-// [Core BPF]: Locally-implemented
-// `solana_sdk::program_utils::limited_deserialize`.
-fn limited_deserialize<T>(input: &[u8]) -> Result<T, ProgramError>
-where
-    T: serde::de::DeserializeOwned,
-{
-    solana_program::program_utils::limited_deserialize(
-        input, 1232, // [Core BPF]: See `solana_sdk::packet::PACKET_DATA_SIZE`
-    )
-    .map_err(|_| ProgramError::InvalidInstructionData)
+// Maximum input buffer length that can be deserialized.
+// See `solana_sdk::packet::PACKET_DATA_SIZE`.
+const MAX_INPUT_LEN: usize = 1232;
+// Maximum vector length for new keys to be appended to a lookup table,
+// provided to the `ExtendLookupTable` instruction.
+// See comments below for `safe_deserialize_instruction`.
+//
+// Take the maximum input length and subtract 4 bytes for the discriminator,
+// 8 bytes for the vector length, then divide that by the size of a `Pubkey`.
+const MAX_NEW_KEYS_VECTOR_LEN: usize = (MAX_INPUT_LEN - 4 - 8) / 32;
+
+// Stub of `AddressLookupTableInstruction` for partial deserialization.
+#[derive(serde::Serialize, serde::Deserialize, PartialEq)]
+enum InstructionStub {
+    Create,
+    Freeze,
+    Extend { vector_len: u64 },
+    Deactivate,
+    Close,
+}
+
+// [Core BPF]: The original Address Lookup Table builtin leverages the
+// `solana_sdk::program_utils::limited_deserialize` method to cap the length of
+// the input buffer at `MAX_INPUT_LEN` (1232). As a result, any input buffer
+// larger than `MAX_INPUT_LEN` will abort deserialization and return
+// `InstructionError::InvalidInstructionData`.
+//
+// Howevever, since `ExtendLookupTable` contains a vector of `Pubkey`, the
+// `limited_deserialize` method will still read the vector's length and attempt
+// to allocate a vector of the designated size. For extremely large length
+// values, this can cause the initial allocation of a large vector to exhuast
+// the BPF program's heap before deserialization can proceed.
+//
+// To mitigate this memory issue, the BPF version of the program has been
+// designed to "peek" the length value for `ExtendLookupTable`, and ensure it
+// cannot allocate a vector that would otherwise violate the input buffer
+// length restriction.
+fn safe_deserialize_instruction(
+    input: &[u8],
+) -> Result<AddressLookupTableInstruction, ProgramError> {
+    match bincode::deserialize::<InstructionStub>(input)
+        .map_err(|_| ProgramError::InvalidInstructionData)?
+    {
+        InstructionStub::Extend { vector_len } if vector_len as usize > MAX_NEW_KEYS_VECTOR_LEN => {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+        _ => {}
+    }
+    solana_program::program_utils::limited_deserialize(input, MAX_INPUT_LEN as u64)
+        .map_err(|_| ProgramError::InvalidInstructionData)
 }
 
 // [Core BPF]: Feature "FKAcEvNgSY79RpqsPNUV5gDyumopH4cEHqUxyfm8b8Ap"
@@ -461,7 +501,7 @@ fn process_close_lookup_table(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
 /// Processes a
 /// `solana_programs_address_lookup_table::instruction::AddressLookupTableInstruction`
 pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> ProgramResult {
-    let instruction = limited_deserialize(input)?;
+    let instruction = safe_deserialize_instruction(input)?;
     match instruction {
         AddressLookupTableInstruction::CreateLookupTable {
             recent_slot,


### PR DESCRIPTION
#### Problem
Similar to https://github.com/solana-program/config/pull/16, the Address Lookup Table program imposes a limit on the provided instruction buffer length. However, the `ExtendLookupTable` instruction uses a vector of pubkeys, resulting in a vector length stored in the first 8 bytes of the buffer after the discriminator.

If that vector length is very large, even if the rest of the buffer is invalid, the allocator in the BPF version will attempt to allocate a large vector and exhaust the heap.

#### Summary of Changes
Add a `safe_deserialize_instruction` helper to check the vector length before attempting deserialization.