### PR TITLE
Program: add custom error codes for readonly writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2719,6 +2719,8 @@ dependencies = [
  "bytemuck",
  "mollusk-svm",
  "mollusk-svm-bencher",
+ "num-derive 0.4.2",
+ "num-traits",
  "serde",
  "solana-frozen-abi 2.0.1",
  "solana-frozen-abi-macro 2.0.1",
@@ -2727,6 +2729,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "test-case",
+ "thiserror",
 ]
 
 [[package]]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -19,10 +19,13 @@ test-sbf = []
 [dependencies]
 bincode = "1.3.3"
 bytemuck = "1.14.1"
+num-derive = "0.4"
+num-traits = "0.2"
 serde = { version = "1.0.193", features = ["derive"] }
 solana-frozen-abi = { version = "2.0.1", optional = true }
 solana-frozen-abi-macro = { version = "2.0.1", optional = true }
 solana-program = "2.0.1"
+thiserror = "1.0.61"
 
 [dev-dependencies]
 mollusk-svm = { version = "0.0.5", features = ["fuzz"] }

--- a/program/benches/compute_units.md
+++ b/program/benches/compute_units.md
@@ -1,3 +1,29 @@
+#### Compute Units: 2024-11-08 13:17:54.004441 UTC
+
+| Name | CUs | Delta |
+|------|------|-------|
+| create_lookup_table | 10759 | +1 |
+| freeze_lookup_table | 1518 | +1 |
+| extend_lookup_table_from_0_to_1 | 6226 | +4 |
+| extend_lookup_table_from_0_to_10 | 8845 | +4 |
+| extend_lookup_table_from_0_to_38 | 17081 | +4 |
+| extend_lookup_table_from_1_to_2 | 6226 | +4 |
+| extend_lookup_table_from_1_to_10 | 8551 | +4 |
+| extend_lookup_table_from_1_to_39 | 17081 | +4 |
+| extend_lookup_table_from_5_to_6 | 6226 | +4 |
+| extend_lookup_table_from_5_to_15 | 8846 | +4 |
+| extend_lookup_table_from_5_to_43 | 17081 | +4 |
+| extend_lookup_table_from_25_to_26 | 6229 | +4 |
+| extend_lookup_table_from_25_to_35 | 8848 | +4 |
+| extend_lookup_table_from_25_to_63 | 17084 | +4 |
+| extend_lookup_table_from_50_to_88 | 17087 | +4 |
+| extend_lookup_table_from_100_to_138 | 17093 | +4 |
+| extend_lookup_table_from_150_to_188 | 17100 | +4 |
+| extend_lookup_table_from_200_to_238 | 17106 | +4 |
+| extend_lookup_table_from_255_to_256 | 6258 | +4 |
+| deactivate_lookup_table | 3152 | +1 |
+| close_lookup_table | 2227 | +1 |
+
 #### Compute Units: 2024-11-07 16:24:48.059441548 UTC
 
 | Name | CUs | Delta |

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -1,8 +1,11 @@
 //! Program entrypoint
 
 use {
-    crate::processor,
-    solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey},
+    crate::{error::AddressLookupTableError, processor},
+    solana_program::{
+        account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
+        pubkey::Pubkey,
+    },
 };
 
 solana_program::entrypoint!(process_instruction);
@@ -11,5 +14,9 @@ fn process_instruction(
     accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    processor::process(program_id, accounts, instruction_data)
+    if let Err(error) = processor::process(program_id, accounts, instruction_data) {
+        error.print::<AddressLookupTableError>();
+        return Err(error);
+    }
+    Ok(())
 }

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -1,0 +1,37 @@
+//! Program error types.
+
+use {
+    num_derive::FromPrimitive,
+    solana_program::{
+        decode_error::DecodeError,
+        msg,
+        program_error::{PrintProgramError, ProgramError},
+    },
+    thiserror::Error,
+};
+
+/// Errors that can be returned by the Config program.
+#[derive(Error, Clone, Debug, Eq, PartialEq, FromPrimitive)]
+pub enum AddressLookupTableError {
+    /// Instruction modified data of a read-only account.
+    #[error("Instruction modified data of a read-only account")]
+    ReadonlyDataModified = 10,
+}
+
+impl PrintProgramError for AddressLookupTableError {
+    fn print<E>(&self) {
+        msg!(&self.to_string());
+    }
+}
+
+impl From<AddressLookupTableError> for ProgramError {
+    fn from(e: AddressLookupTableError) -> Self {
+        ProgramError::Custom(e as u32)
+    }
+}
+
+impl<T> DecodeError<T> for AddressLookupTableError {
+    fn type_of() -> &'static str {
+        "AddressLookupTableError"
+    }
+}

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -15,7 +15,7 @@ use {
 pub enum AddressLookupTableError {
     /// Instruction modified data of a read-only account.
     #[error("Instruction modified data of a read-only account")]
-    ReadonlyDataModified = 10,
+    ReadonlyDataModified = 10, // Avoid collisions with System.
 }
 
 impl PrintProgramError for AddressLookupTableError {

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -3,6 +3,7 @@
 
 #[cfg(all(target_os = "solana", feature = "bpf-entrypoint"))]
 mod entrypoint;
+pub mod error;
 pub mod instruction;
 pub mod processor;
 pub mod state;


### PR DESCRIPTION
#### Problem
Working more with the Firedancer conformance harness, yet another inconsequential mismatch between the BPF version and its original builtin version has popped up.

When a builtin program attempts to write to an executable or read-only account, it will be immediately rejected by the `TransactionContext`. However, BPF programs do not query the `TransactionContext` for the ability to perform a write. Instead, they perform writes at-will, and the loader will inspect the serialized account memory region for any account update violations _after_ the VM has completed execution.

The loader's inspection will catch any unauthorized modifications, however, when the exact same data is written to the account, thus rendering the serialized account state unchanged, the program succeeds.

#### Summary of Changes

In order to maximize backwards compatibility between the BPF version and its original builtin, we add these checks from `TransactionContext` to the program directly, to throw even when the data being written is the same as what's currently in the account.

Unfortunately, the two `InstructionError` variants thrown do not have `ProgramError` counterparts, so we mock them out with custom error codes.