### PR TITLE
program: adjust account load ordering to match builtin

### DIFF
--- a/program/benches/compute_units.md
+++ b/program/benches/compute_units.md
@@ -1,3 +1,29 @@
+#### Compute Units: 2024-11-13 09:15:26.655388 UTC
+
+| Name | CUs | Delta |
+|------|------|-------|
+| create_lookup_table | 10756 | -3 |
+| freeze_lookup_table | 1518 | -- |
+| extend_lookup_table_from_0_to_1 | 6227 | +1 |
+| extend_lookup_table_from_0_to_10 | 8846 | +1 |
+| extend_lookup_table_from_0_to_38 | 17082 | +1 |
+| extend_lookup_table_from_1_to_2 | 6227 | +1 |
+| extend_lookup_table_from_1_to_10 | 8552 | +1 |
+| extend_lookup_table_from_1_to_39 | 17082 | +1 |
+| extend_lookup_table_from_5_to_6 | 6227 | +1 |
+| extend_lookup_table_from_5_to_15 | 8847 | +1 |
+| extend_lookup_table_from_5_to_43 | 17082 | +1 |
+| extend_lookup_table_from_25_to_26 | 6230 | +1 |
+| extend_lookup_table_from_25_to_35 | 8849 | +1 |
+| extend_lookup_table_from_25_to_63 | 17085 | +1 |
+| extend_lookup_table_from_50_to_88 | 17088 | +1 |
+| extend_lookup_table_from_100_to_138 | 17094 | +1 |
+| extend_lookup_table_from_150_to_188 | 17101 | +1 |
+| extend_lookup_table_from_200_to_238 | 17107 | +1 |
+| extend_lookup_table_from_255_to_256 | 6259 | +1 |
+| deactivate_lookup_table | 3152 | -- |
+| close_lookup_table | 2228 | +1 |
+
 #### Compute Units: 2024-11-08 13:17:54.004441 UTC
 
 | Name | CUs | Delta |

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -136,7 +136,6 @@ fn process_create_lookup_table(
     let lookup_table_info = next_account_info(accounts_iter)?;
     let authority_info = next_account_info(accounts_iter)?;
     let payer_info = next_account_info(accounts_iter)?;
-    let _system_program_info = next_account_info(accounts_iter)?;
 
     if !payer_info.is_signer {
         msg!("Payer account must be a signer");
@@ -191,6 +190,8 @@ fn process_create_lookup_table(
         )?;
     }
 
+    let _system_program_info = next_account_info(accounts_iter)?;
+
     invoke_signed(
         &system_instruction::allocate(lookup_table_info.key, lookup_table_data_len as u64),
         &[lookup_table_info.clone()],
@@ -215,12 +216,13 @@ fn process_freeze_lookup_table(program_id: &Pubkey, accounts: &[AccountInfo]) ->
     let accounts_iter = &mut accounts.iter();
 
     let lookup_table_info = next_account_info(accounts_iter)?;
-    let authority_info = next_account_info(accounts_iter)?;
 
     if lookup_table_info.owner != program_id {
         msg!("Lookup table owner should be the Address Lookup Table program");
         return Err(ProgramError::InvalidAccountOwner);
     }
+
+    let authority_info = next_account_info(accounts_iter)?;
 
     if !authority_info.is_signer {
         msg!("Authority account must be a signer");
@@ -268,12 +270,13 @@ fn process_extend_lookup_table(
     let accounts_iter = &mut accounts.iter();
 
     let lookup_table_info = next_account_info(accounts_iter)?;
-    let authority_info = next_account_info(accounts_iter)?;
 
     if lookup_table_info.owner != program_id {
         msg!("Lookup table owner should be the Address Lookup Table program");
         return Err(ProgramError::InvalidAccountOwner);
     }
+
+    let authority_info = next_account_info(accounts_iter)?;
 
     if !authority_info.is_signer {
         msg!("Authority account must be a signer");
@@ -398,12 +401,13 @@ fn process_extend_lookup_table(
 
     if required_lamports > 0 {
         let payer_info = next_account_info(accounts_iter)?;
-        let _system_program_info = next_account_info(accounts_iter)?;
 
         if !payer_info.is_signer {
             msg!("Payer account must be a signer");
             return Err(ProgramError::MissingRequiredSignature);
         }
+
+        let _system_program_info = next_account_info(accounts_iter)?;
 
         invoke(
             &system_instruction::transfer(payer_info.key, lookup_table_info.key, required_lamports),
@@ -418,12 +422,13 @@ fn process_deactivate_lookup_table(program_id: &Pubkey, accounts: &[AccountInfo]
     let accounts_iter = &mut accounts.iter();
 
     let lookup_table_info = next_account_info(accounts_iter)?;
-    let authority_info = next_account_info(accounts_iter)?;
 
     if lookup_table_info.owner != program_id {
         msg!("Lookup table owner should be the Address Lookup Table program");
         return Err(ProgramError::InvalidAccountOwner);
     }
+
+    let authority_info = next_account_info(accounts_iter)?;
 
     if !authority_info.is_signer {
         msg!("Authority account must be a signer");
@@ -466,18 +471,20 @@ fn process_close_lookup_table(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
     let accounts_iter = &mut accounts.iter();
 
     let lookup_table_info = next_account_info(accounts_iter)?;
-    let authority_info = next_account_info(accounts_iter)?;
-    let recipient_info = next_account_info(accounts_iter)?;
 
     if lookup_table_info.owner != program_id {
         msg!("Lookup table owner should be the Address Lookup Table program");
         return Err(ProgramError::InvalidAccountOwner);
     }
 
+    let authority_info = next_account_info(accounts_iter)?;
+
     if !authority_info.is_signer {
         msg!("Authority account must be a signer");
         return Err(ProgramError::MissingRequiredSignature);
     }
+
+    let recipient_info = next_account_info(accounts_iter)?;
 
     // [Core BPF]: Here the legacy built-in version of ALT fallibly checks to
     // ensure the number of instruction accounts is 3.


### PR DESCRIPTION
#### Problem
Working with the Firedancer tooling some more, I realized that - in many cases - the builtin version of ALT will load an account and then run one or more checks on it before moving onto loading the next one.

In the BPF version, we follow the common BPF program pattern of loading all accounts up front with subsequent calls to `next_account_info`. However, this can cause `ProgramError::NotEnoughAccountKeys` in situations where the builtin may have thrown a different error (such as `InstructionError::IncorrectOwner`).

#### Summary
Change the ordering of account loads and checks to exactly match the builtin version.