### PR TITLE
program: map pubkey err to customs

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -159,7 +159,8 @@ fn process_create_lookup_table(
         &derivation_slot.to_le_bytes(),
         &[bump_seed],
     ];
-    let derived_table_key = Pubkey::create_program_address(derived_table_seeds, program_id)?;
+    let derived_table_key = Pubkey::create_program_address(derived_table_seeds, program_id)
+        .map_err(AddressLookupTableError::from)?;
 
     if lookup_table_info.key != &derived_table_key {
         msg!(


### PR DESCRIPTION
#### Problem
I don't really like this change, but I'm putting it up here for discussion.

In the SDK, `PubkeyError` can be mapped to `ProgramError`, but not `InstructionError`. That means the builtin will throw custom error codes when `Pubkey::create_program_address` fails, but the BPF version will throw a proper `ProgramError`.

#### Summary of Changes
Put some awful indirection into the processor to map `PubkeyError` to custom error codes, just like the builtin.