### PR TITLE
program: patch a few small conformance mismatches

### DIFF
--- a/program/benches/compute_units.md
+++ b/program/benches/compute_units.md
@@ -1,3 +1,29 @@
+#### Compute Units: 2024-11-20 05:26:29.922433084 UTC
+
+| Name | CUs | Delta |
+|------|------|-------|
+| create_lookup_table | 10755 | -1 |
+| freeze_lookup_table | 1518 | -- |
+| extend_lookup_table_from_0_to_1 | 6226 | -1 |
+| extend_lookup_table_from_0_to_10 | 8845 | -1 |
+| extend_lookup_table_from_0_to_38 | 17081 | -1 |
+| extend_lookup_table_from_1_to_2 | 6226 | -1 |
+| extend_lookup_table_from_1_to_10 | 8551 | -1 |
+| extend_lookup_table_from_1_to_39 | 17081 | -1 |
+| extend_lookup_table_from_5_to_6 | 6226 | -1 |
+| extend_lookup_table_from_5_to_15 | 8846 | -1 |
+| extend_lookup_table_from_5_to_43 | 17081 | -1 |
+| extend_lookup_table_from_25_to_26 | 6229 | -1 |
+| extend_lookup_table_from_25_to_35 | 8848 | -1 |
+| extend_lookup_table_from_25_to_63 | 17084 | -1 |
+| extend_lookup_table_from_50_to_88 | 17087 | -1 |
+| extend_lookup_table_from_100_to_138 | 17093 | -1 |
+| extend_lookup_table_from_150_to_188 | 17100 | -1 |
+| extend_lookup_table_from_200_to_238 | 17106 | -1 |
+| extend_lookup_table_from_255_to_256 | 6258 | -1 |
+| deactivate_lookup_table | 3152 | -- |
+| close_lookup_table | 2234 | +7 |
+
 #### Compute Units: 2024-11-13 16:51:07.839873 UTC
 
 | Name | CUs | Delta |

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -29,6 +29,9 @@ pub enum AddressLookupTableError {
     /// Instruction modified data of a read-only account.
     #[error("Instruction modified data of a read-only account")]
     ReadonlyDataModified = 10, // Avoid collisions with System.
+    /// Instruction changed the balance of a read-only account.
+    #[error("Instruction changed the balance of a read-only account")]
+    ReadonlyLamportsChanged,
 }
 
 impl PrintProgramError for AddressLookupTableError {

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -536,6 +536,10 @@ fn process_close_lookup_table(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
         .ok_or::<ProgramError>(ProgramError::ArithmeticOverflow)?;
     **recipient_info.try_borrow_mut_lamports()? = new_recipient_lamports;
 
+    if !lookup_table_info.is_writable {
+        return Err(AddressLookupTableError::ReadonlyDataModified.into());
+    }
+
     // Lookup tables are _not_ reassigned when closed.
     lookup_table_info.realloc(0, true)?;
     **lookup_table_info.try_borrow_mut_lamports()? = 0;

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -537,8 +537,8 @@ fn process_close_lookup_table(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
     **recipient_info.try_borrow_mut_lamports()? = new_recipient_lamports;
 
     // Lookup tables are _not_ reassigned when closed.
-    **lookup_table_info.try_borrow_mut_lamports()? = 0;
     lookup_table_info.realloc(0, true)?;
+    **lookup_table_info.try_borrow_mut_lamports()? = 0;
 
     Ok(())
 }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -534,6 +534,11 @@ fn process_close_lookup_table(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
         .lamports()
         .checked_add(recipient_info.lamports())
         .ok_or::<ProgramError>(ProgramError::ArithmeticOverflow)?;
+
+    if !recipient_info.is_writable {
+        return Err(AddressLookupTableError::ReadonlyLamportsChanged.into());
+    }
+
     **recipient_info.try_borrow_mut_lamports()? = new_recipient_lamports;
 
     if !lookup_table_info.is_writable {

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -43,7 +43,9 @@ fn get_lookup_table_status(
         Ok(LookupTableStatus::Deactivating {
             remaining_blocks: MAX_ENTRIES.saturating_add(1),
         })
-    } else if let Some(slot_position) = SlotHashesSysvar::position(&deactivation_slot)? {
+    } else if let Some(slot_position) = SlotHashesSysvar::position(&deactivation_slot)
+        .map_err(|_| ProgramError::UnsupportedSysvar)?
+    {
         // Deactivation requires a cool-down period to give in-flight transactions
         // enough time to land and to remove indeterminism caused by transactions
         // loading addresses in the same slot when a table is closed. The
@@ -143,7 +145,10 @@ fn process_create_lookup_table(
     }
 
     let derivation_slot = {
-        if SlotHashesSysvar::get(&untrusted_recent_slot)?.is_some() {
+        if SlotHashesSysvar::get(&untrusted_recent_slot)
+            .map_err(|_| ProgramError::UnsupportedSysvar)?
+            .is_some()
+        {
             Ok(untrusted_recent_slot)
         } else {
             msg!("{} is not a recent slot", untrusted_recent_slot);


### PR DESCRIPTION
Just a few more small conformance mismatches that came from working with Firedancer's tooling.

1. Reordering lamport deduction and account realloc (on `CloseLookupTable`): This ordering now matches the builtin exactly.
2. Add readonly check for lookup table on `CloseLookupTable`: This throws a `ReadonlyDataModified` error at the proper callsite.
3. Add readonly _lamport_ check for recipient on `CloseLookupTable`: This one is a little pedantic, but again, it provides exact backwards compatibility with error codes and throw/call sites.
4. Map `sol_get_sysvar` to `UnsupportedSysvar`: When the slot hashes data is malformed, the API for `SlotHashesSysvar` throws `InvalidAccountData` (which I think does make more sense), however the sysvar cache will throw `UnsupportedSysvar` for the builtin. Updates to align the codes.