### PR TITLE
program: Remove test-sbf feature

### DIFF
--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -10,7 +10,6 @@ edition = { workspace = true }
 
 [features]
 fetch = ["dep:solana-client", "dep:solana-sdk"]
-test-sbf = []
 serde = ["dep:serde", "dep:serde_with", "kaigan/serde"]
 
 [dependencies]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,7 +13,6 @@ program-id = "AddressLookupTab1e1111111111111111111111111"
 
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
-test-sbf = []
 
 [dependencies]
 bincode = { workspace = true }

--- a/program/tests/close_lookup_table_ix.rs
+++ b/program/tests/close_lookup_table_ix.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "test-sbf")]
-
 mod common;
 
 use {

--- a/program/tests/common.rs
+++ b/program/tests/common.rs
@@ -1,6 +1,4 @@
 #![allow(dead_code)]
-#![cfg(feature = "test-sbf")]
-
 use {
     mollusk_svm::Mollusk,
     solana_address_lookup_table_program::state::{AddressLookupTable, LookupTableMeta},

--- a/program/tests/create_lookup_table_ix.rs
+++ b/program/tests/create_lookup_table_ix.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "test-sbf")]
-
 mod common;
 
 use {

--- a/program/tests/deactivate_lookup_table_ix.rs
+++ b/program/tests/deactivate_lookup_table_ix.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "test-sbf")]
-
 mod common;
 
 use {

--- a/program/tests/extend_lookup_table_ix.rs
+++ b/program/tests/extend_lookup_table_ix.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "test-sbf")]
-
 mod common;
 
 use {

--- a/program/tests/freeze_lookup_table_ix.rs
+++ b/program/tests/freeze_lookup_table_ix.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "test-sbf")]
-
 mod common;
 
 use {


### PR DESCRIPTION
#### Problem

The test-sbf feature is no longer needed, since we don't run `cargo test-sbf`, and instead run `SBF_OUT_DIR=... cargo test` by hand.

#### Summary of changes

Remove the test-sbf feature and all usage of it.