### PR TITLE
scripts: Wait longer for test validator to be ready

### DIFF
--- a/scripts/restart-test-validator.sh
+++ b/scripts/restart-test-validator.sh
@@ -31,7 +31,7 @@ for i in {1..8}; do
   fi
 
   SLOT=$(solana slot -ul 2>/dev/null)
-  if [[ "$SLOT" =~ ^[0-9]+$ ]] && [ "$SLOT" -gt 0 ]; then
+  if [[ "$SLOT" =~ ^[0-9]+$ ]] && [ "$SLOT" -gt 8 ]; then
     echo -e "\nTest validator is ready. Slot: $SLOT"
     exit 0
   fi


### PR DESCRIPTION
#### Problem

There are some CI failures on the JS tests because we run the tests before the program has been properly deployed the validator at genesis.

#### Summary of changes

Wait a little longer during the restart script.